### PR TITLE
docs: fix bilingual README hero layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,7 @@
 <p align="center">
   开源、本地优先的 Windows 知识画布与学习笔记软件<br>
   适合视觉笔记、个人知识管理（PKM）、课程整理、研究构思与思维导图<br>
-  目前支持的语言：简体中文和英文。<br>
-  Currently supported languages: Simplified Chinese, English.
-</p>
-
-
-<p align="center">
-  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-111111?style=flat-square"></a>
-  <img alt="Windows 10 and 11" src="https://img.shields.io/badge/platform-Windows%2010%20%7C%2011-2563eb?style=flat-square">
-  <img alt="Local first" src="https://img.shields.io/badge/data-local--first-2f855a?style=flat-square">
+  界面语言：简体中文 · English
 </p>
 
 <p align="center">
@@ -26,10 +18,17 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest"><<<img width="2559" height="1599" alt="image" src="https://github.com/user-attachments/assets/fed0dc96-c635-4e79-99c4-fef8f8eb8195" />
+  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/yamibk/Relatum-Opensource?style=flat-square"></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-111111?style=flat-square"></a>
+  <img alt="Windows 10 and 11" src="https://img.shields.io/badge/platform-Windows%2010%20%7C%2011-2563eb?style=flat-square">
+  <img alt="Local first" src="https://img.shields.io/badge/data-local--first-2f855a?style=flat-square">
+</p>
 
-
-![Relatum 思维导图与一键排版界面](docs/images/relatum-mind-map.png)
+<p align="center">
+  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest">
+    <img src="https://github.com/user-attachments/assets/fed0dc96-c635-4e79-99c4-fef8f8eb8195" alt="Relatum 自由画布、节点连接与思维导图界面">
+  </a>
+</p>
 
 ## Relatum 是什么？
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,7 +6,8 @@
 
 <p align="center">
   An open-source, local-first knowledge canvas and study workspace for Windows<br>
-  Built for visual notes, personal knowledge management, course work, research, and mind maps
+  Built for visual notes, personal knowledge management, course work, research, and mind maps<br>
+  Interface languages: Simplified Chinese · English
 </p>
 
 <p align="center">
@@ -23,7 +24,11 @@
   <img alt="Local first" src="https://img.shields.io/badge/data-local--first-2f855a?style=flat-square">
 </p>
 
-![Relatum mind map with automatic layout](docs/images/relatum-mind-map.png)
+<p align="center">
+  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest">
+    <img src="https://github.com/user-attachments/assets/fed0dc96-c635-4e79-99c4-fef8f8eb8195" alt="Relatum freeform canvas with connected notes and mind maps">
+  </a>
+</p>
 
 ## What is Relatum?
 


### PR DESCRIPTION
## What changed

- Fixed the malformed, unclosed hero-image markup in the Chinese README.
- Removed the stray `<<<` text and restored the missing release badge.
- Reorganized the header into a consistent description, navigation, badges, and hero-image layout.
- Added the same new hero image to the English README.
- Kept the existing mind-map image in the later screenshot gallery to avoid duplicate full-width images above the introduction.
- Simplified the supported-language note in both languages.

## Why

The manually added image was embedded inside an incomplete link tag, which caused literal symbols and broken spacing to appear in GitHub's rendered README. The English README also continued using the previous hero image.

## Impact

Documentation only. Runtime code and release assets are unchanged.

## Validation

- Balanced opening and closing `<p>` and `<a>` tags in both READMEs
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File .\scripts\check-public.ps1`
- Confirmed the GitHub-hosted hero image URL responds successfully
