### PR TITLE
Fix multiline node editing data loss

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,3 +39,7 @@ jobs:
           Get-ChildItem assets -Recurse -Filter *.js |
             Where-Object { $_.FullName -notmatch '\\vendor\\' } |
             ForEach-Object { node --check $_.FullName }
+
+      - name: Run rich-text regression tests
+        shell: pwsh
+        run: node tests/richtext-regression.js

--- a/assets/canvas.js
+++ b/assets/canvas.js
@@ -13033,6 +13033,19 @@
     // ── 节点文字编辑 ───────────────────────
     function enterNodeEdit(node, isNew, caretPoint) {
       if (isDecorationNode(node)) return;
+      // 已在编辑同一个节点时，双击只移动光标，绝不能用尚未提交的模型值
+      // 重建 DOM；否则多行输入会在一次双击中被旧内容覆盖，且不进入历史栈。
+      if (editingNodeId === node.id) {
+        const activeEl = nodeMap.get(node.id);
+        const activeText = activeEl && activeEl.querySelector('.node-text');
+        if (!activeEl || !activeText) return;
+        activeEl.classList.add('editing');
+        selectNodes([node.id], false);
+        activeText.focus();
+        if (caretPoint) placeEditableCaretFromPoint(activeText, caretPoint.x, caretPoint.y);
+        if (!isCodeNode(node)) applyMarkHighlight(activeText);
+        return;
+      }
       if (editingNodeId !== null && editingNodeId !== node.id) commitNodeEdit();
       if (editingEdgeId !== null) commitEdgeEdit();
 
@@ -13239,27 +13252,29 @@
       const wasNew = editingIsNew;
       const oldText = editingOriginalText;
       const oldMarks = editingOriginalMarks;
-      editingNodeId = null;
-      editingIsNew = false;
-      editingOriginalText = '';
-      editingOriginalMarks = [];
-      scheduleTextDock();
-
       const node = findNode(id);
       const el = nodeMap.get(id);
       if (!node || !el) return;
       const textEl = el.querySelector('.node-text');
-      // 代码保留首尾空白与缩进；普通标题多行仍只 trim 首尾。
+      // 先完整读取并规范化草稿，再切换编辑状态。读取阶段若意外失败，节点仍
+      // 保持原编辑态与实时 DOM，不会落入“模型是旧值、界面是新值”的半提交状态。
       const draft = isCodeNode(node)
         ? { text: textEl.textContent || '', marks: [] }
         : canonicalRichDraft(readRichEditable(textEl));
       const rawText = draft.text;
+      // 代码保留首尾空白与缩进；普通标题多行仍只 trim 首尾。
       const leading = isCodeNode(node) ? 0 : (rawText.match(/^\s*/) || [''])[0].length;
       const trailing = isCodeNode(node) ? 0 : (rawText.match(/\s*$/) || [''])[0].length;
       const newText = isCodeNode(node) ? rawText : rawText.slice(leading, Math.max(leading, rawText.length - trailing));
       const newMarks = isCodeNode(node) || !RichText ? []
         : RichText.slice(rawText, draft.marks, leading, rawText.length - trailing);
       const marksChanged = JSON.stringify(newMarks) !== JSON.stringify(oldMarks);
+
+      editingNodeId = null;
+      editingIsNew = false;
+      editingOriginalText = '';
+      editingOriginalMarks = [];
+      scheduleTextDock();
 
       clearMarkHighlight();        // Y2：退出编辑清掉标记高亮
       hideSelToolbar();            // 退出编辑收起选中工具栏

--- a/assets/richtext.js
+++ b/assets/richtext.js
@@ -394,8 +394,8 @@
     while (el && el !== root) {
       if (el.dataset) {
         if (!style.size && SIZES.has(el.dataset.rtSize)) style.size = el.dataset.rtSize;
-        if (!style.color && COLORS.has(el.dataset.rtColor)) style.color = el.dataset.rtColor;
-        if (!style.highlight && COLORS.has(el.dataset.rtHighlight)) style.highlight = el.dataset.rtHighlight;
+        if (!style.color && TEXT_COLORS.has(el.dataset.rtColor)) style.color = el.dataset.rtColor;
+        if (!style.highlight && HIGHLIGHT_COLORS.has(el.dataset.rtHighlight)) style.highlight = el.dataset.rtHighlight;
         if (!style.bold && el.dataset.rtBold === '1') style.bold = true;
       }
       el = el.parentElement;
@@ -403,18 +403,36 @@
     return style;
   }
 
+  function editablePlainText(root) {
+    if (!root) return '';
+    // contenteditable 在不同浏览器、输入法与光标位置下可能把 Enter 表示成
+    // \r / \n 文本、<br>，或嵌套的 <div>/<p>。innerText 是浏览器对这些
+    // 可视行边界的统一纯文本投影；textContent 会漏掉 <br> 与块级换行。
+    const rendered = typeof root.innerText === 'string' ? root.innerText : (root.textContent || '');
+    return String(rendered).replace(/\r\n?/g, '\n');
+  }
+
   function extractEditable(root) {
     if (!root || !global.document) return { text: '', marks: [] };
-    let text = '';
+    const text = editablePlainText(root);
     const marks = [];
     const walker = global.document.createTreeWalker(root, global.NodeFilter.SHOW_TEXT, null);
+    let cursor = 0;
     let node;
     while ((node = walker.nextNode())) {
-      const value = node.nodeValue || '';
-      const start = text.length;
-      text += value;
+      const value = String(node.nodeValue || '').replace(/\r\n?/g, '\n');
+      if (!value) continue;
+      // innerText 会在 <br> / 块级元素之间补 \n；从上一个文本节点之后向前
+      // 匹配，既跨过这些合成换行，也能稳定处理内容相同的重复文本节点。
+      const found = text.indexOf(value, cursor);
+      // 若浏览器因隐藏内容等原因没有把某个 DOM 文本投影到 innerText，宁可
+      // 放弃那一段格式，也不要把样式错误套到后面的可见文字上。
+      if (found < 0) continue;
+      const start = found;
+      const end = start + value.length;
       const style = styleFromAncestors(node, root);
-      if (value && hasStyle(style)) marks.push(Object.assign({ start: start, end: text.length }, style));
+      if (end > start && hasStyle(style)) marks.push(Object.assign({ start: start, end: end }, style));
+      cursor = end;
     }
     return { text: text, marks: normalize(text, marks) };
   }

--- a/tests/richtext-regression.js
+++ b/tests/richtext-regression.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+function text(value) {
+  return { nodeType: 3, nodeName: '#text', nodeValue: value, parentElement: null };
+}
+
+function element(tagName, children, dataset, innerText) {
+  const el = {
+    nodeType: 1,
+    nodeName: String(tagName || 'div').toUpperCase(),
+    tagName: String(tagName || 'div').toUpperCase(),
+    dataset: dataset || {},
+    children: children || [],
+    parentElement: null,
+  };
+  el.children.forEach(function (child) { child.parentElement = el; });
+  if (innerText !== undefined) el.innerText = innerText;
+  return el;
+}
+
+global.NodeFilter = { SHOW_TEXT: 4 };
+global.document = {
+  createTreeWalker: function (root) {
+    const nodes = [];
+    function visit(node) {
+      if (!node) return;
+      if (node.nodeType === 3) { nodes.push(node); return; }
+      (node.children || []).forEach(visit);
+    }
+    visit(root);
+    let index = 0;
+    return { nextNode: function () { return nodes[index++] || null; } };
+  },
+};
+
+require('../assets/richtext.js');
+const RichText = global.RelatumRichText;
+
+function extract(root) {
+  return RichText.extractEditable(root);
+}
+
+// Enter may arrive as a carriage return text node. Persist one canonical \n.
+{
+  const root = element('div', [text('123\r456')], {}, '123\r456');
+  assert.deepEqual(extract(root), { text: '123\n456', marks: [] });
+}
+
+// Browser-created block lines must not throw and must retain their visible boundary.
+{
+  const secondLine = element('div', [text('456')]);
+  const root = element('div', [text('123'), secondLine], {}, '123\n456');
+  assert.deepEqual(extract(root), { text: '123\n456', marks: [] });
+}
+
+// <br> contributes a visible line break through innerText even though it has no text node.
+{
+  const root = element('div', [text('123'), element('br'), text('456')], {}, '123\n456');
+  assert.deepEqual(extract(root), { text: '123\n456', marks: [] });
+}
+
+// Rich runs on either side of a generated line break keep correct offsets and palettes.
+{
+  const first = element('span', [text('same')], { rtBold: '1' });
+  const second = element('span', [text('same')], { rtColor: 'red', rtHighlight: 'yellow' });
+  const block = element('div', [second]);
+  const root = element('div', [first, block], {}, 'same\nsame');
+  assert.deepEqual(extract(root), {
+    text: 'same\nsame',
+    marks: [
+      { start: 0, end: 4, bold: true },
+      { start: 5, end: 9, color: 'red', highlight: 'yellow' },
+    ],
+  });
+}
+
+// DOM-only text omitted from innerText must not shift its style onto visible content.
+{
+  const hidden = element('span', [text('hidden')], { rtColor: 'red' });
+  const visible = element('span', [text('visible')], { rtBold: '1' });
+  const root = element('div', [hidden, visible], {}, 'visible');
+  assert.deepEqual(extract(root), {
+    text: 'visible',
+    marks: [{ start: 0, end: 7, bold: true }],
+  });
+}
+
+console.log('richtext regression tests passed');


### PR DESCRIPTION
## What changed

- Preserve visual line boundaries from Enter across text nodes, `<br>`, and block elements.
- Fix rich-text color/highlight extraction for nested editable markup.
- Keep node editing state intact until draft extraction succeeds.
- Prevent repeated double-clicks on the active editor from rebuilding it from stale model data.
- Add regression coverage and run it in CI.

## Why

Double-clicking any multi-line node could clear or truncate its content. The failed edit was not added to history, so undo could not recover it. A related commit failure also caused the first blank-canvas click to exit editing without deselecting the node.

## Root cause

Rich-text extraction referenced an undefined palette constant and only concatenated text nodes, missing browser-generated line boundaries. The commit path cleared editing state before extraction completed, leaving the live DOM and saved model out of sync when extraction threw.

## Impact

Multi-line nodes now retain their content through Enter, rapid double-click, commit, undo, and redo. One blank-canvas click exits editing and deselects the node.

## Validation

- Real Enter input and rapid mouse double-click visual validation
- Plain and formatted multi-line nodes
- Single-click exit/deselect behavior
- Undo and redo
- JavaScript syntax checks
- Python bytecode compilation
- `node tests/richtext-regression.js`
- Public repository safety check
