### PR TITLE
Strengthen immersive title bar guides

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -11988,7 +11988,7 @@ body.editor-page.topbar-pending .editor-top-bar {
   position: absolute;
   inset: 0 -320px;
   z-index: -2;
-  opacity: 0.75;
+  opacity: 0.93;
   pointer-events: none;
   transform: translate3d(0, 0, 0);
   contain: paint;


### PR DESCRIPTION
## What changed

- increase the full-immersive title-bar guide opacity from `0.75` to `0.93`

## Why

The title-bar continuation remained noticeably lighter than the canvas guide, especially on pale immersive backgrounds.

## Impact

Guide continuity across the title bar is clearer while retaining the existing top-edge fade, readability wash, and soft-toolbar behavior.

## Validation

- `git diff --check`
- `scripts/check-public.ps1`
