### PR TITLE
Enlarge activity page headings

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -26416,6 +26416,12 @@ body.start-page[data-start-theme="dark"] .star-tooltip {
   font-weight: 610;
   letter-spacing: -0.045em;
 }
+.study-cadence-head h2,
+.cadence-starmap h3 {
+  font-size: clamp(29px, 3.4vw, 46px);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+}
 .star-mode-switch {
   border-color: var(--border);
   background: color-mix(in srgb, var(--text) 3.5%, transparent);


### PR DESCRIPTION
## What changed

- Increased the responsive size of the “年度足迹” and “足迹星图” headings.
- Kept the existing typeface and page structure.
- Applied a 700 weight and the same compact tracking used by the surrounding visual system.

## Why

The activity page headings were visually weaker than the calendar page heading. This gives them a clearer hierarchy while keeping the change narrowly scoped.

## Impact

Only the two activity-page headings are affected. No data or application behavior changes.

## Validation

Checks were intentionally skipped at the user's request.
