### PR TITLE
Clarify default fill reset label

### DIFF
--- a/assets/canvas.js
+++ b/assets/canvas.js
@@ -9534,7 +9534,7 @@
       if (dpResetFill) {
         dpResetFill.hidden = false;
         dpResetFill.textContent = editingDefaults
-          ? (englishUi ? 'Reset default colors' : '重置默认颜色')
+          ? (englishUi ? 'Reset default fill color' : '重置默认填充颜色')
           : (englishUi ? 'Apply preset colors' : '应用预设颜色');
       }
       if (dpDelete) dpDelete.hidden = editingDefaults;

--- a/assets/editor.html
+++ b/assets/editor.html
@@ -1289,7 +1289,7 @@
             </div>
           </div>
           <button type="button" class="sp-reset sp-reset-compact" data-role="decor-reset-fill">
-            重置默认颜色
+            重置默认填充颜色
           </button>
         </div>
         <div class="sp-field" data-role="decor-title-tone-wrap" hidden>

--- a/assets/i18n.js
+++ b/assets/i18n.js
@@ -559,7 +559,7 @@
     '宽度': 'Width', '高度': 'Height', '字号': 'Font size', '旋转角度': 'Rotation',
     '双线': 'Double', '边框粗细': 'Border weight', '填充颜色': 'Fill color',
     '文字颜色': 'Text color', '预设颜色': 'Preset colors', '填充': 'Fill',
-    '淡': 'Tint', '实': 'Solid', '重置默认颜色': 'Reset colors',
+    '淡': 'Tint', '实': 'Solid', '重置默认填充颜色': 'Reset default fill color',
     '标题文字语义': 'Title contrast', '浅色': 'Light', '深色': 'Dark',
     '浅色字适合较深的标题底色；深色字适合柠檬黄等明亮标题底色。': 'Light text suits dark title fills; dark text suits bright fills such as lemon yellow.',
     '滑条进度': 'Slider progress', '透明度': 'Opacity', '显示图层': 'Layer',


### PR DESCRIPTION
## What changed

- Rename the decoration preset action from “重置默认颜色” to the more precise “重置默认填充颜色”.
- Update the matching English runtime label to “Reset default fill color”.
- Keep the static editor markup, dynamic canvas label, and shared i18n mapping synchronized.

## Why

The previous wording suggested that the action reset every color-related setting, while it only resets the default fill color.

## User impact

The button now describes its actual behavior more clearly in both Chinese and English. No data model or interaction behavior changes.

## Validation

- Public repository boundary scan
- Python source compilation
- Syntax checks for all handwritten JavaScript
- Rich-text regression tests
- Markdown table regression tests
- Compact table contract tests
- 8 Python unit tests
- Verified that the old Chinese and English labels no longer remain in frontend assets
