### PR TITLE
Refine English starmap heading

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -47,6 +47,12 @@ html[data-ui-language="en"] {
   --font-interface-en: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 html[data-ui-language="en"] body { font-family: var(--font-interface-en); }
+html[data-ui-language="en"] .cadence-starmap h3 {
+  font-family: var(--font-display-en);
+  font-weight: 500;
+  letter-spacing: -.045em;
+  line-height: .96;
+}
 html[data-ui-language="en"] .study-eyebrow,
 html[data-ui-language="en"] .desktop-settings-eyebrow {
   font-size: 10px;


### PR DESCRIPTION
## 改动概览

- 为英文界面下的足迹星图标题应用统一的展示衬线字体。
- 调整英文标题字重、字距与行高，使其与其他英文页面主标题保持一致。

## 影响

该改动仅影响 `data-ui-language=en` 时的 `.cadence-starmap h3`，中文界面、星图布局和交互均不变。

## 验证

- 确认选择器命中实际星图标题并具有足够的层叠优先级。
- Markdown 表格、富文本和紧凑表格三组前端回归通过。
- `git diff --check` 通过。