### PR TITLE
feat: add Microsoft Store MSIX packaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,8 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 | `ai_plan.py` | AI 助手 V2 的纯标准库计划层；集中维护紧凑提示词、JSON 提取、动作协议、安全校验和结构修复提示，不写用户数据。 |
 | `desktop.py` | pywebview 桌面壳、WebView2 检测、无边框窗口、窗口状态、未保存关闭确认和动态背景生命周期协调。 |
 | `windows_wallpaper.py` | Windows 倒数日动态桌面背景宿主；由主进程管理托盘与生命周期，并从同一个 `Relatum.exe` 启动隔离的只读 WebView2 子进程，严格挂载到 Explorer 的专用全屏 `WorkerW`，同时负责主屏尺寸跟踪、单背景互斥、进程间通信和安全清理。 |
-| `build-desktop.ps1` | PyInstaller onedir 打包，输出 `Relatum-release/Relatum.exe`。脚本保持 ASCII。 |
+| `build-desktop.ps1` | PyInstaller onedir 便携版打包，输出 `Relatum-release/Relatum.exe`。脚本保持 ASCII。 |
+| `build-msix.ps1` | Microsoft Store x64 MSIX 打包；复用便携版产物，生成匹配商店身份的清单与图标，输出 `Relatum-store/*.msixupload`。脚本保持 ASCII。 |
 | `start.ps1`、`打开画布.bat` | 源码模式启动器，查找 Python 并运行 `app.py`。 |
 | `index.html` | 起步页壳，书脊导航、最近画布、学习/速记/日历/复习/专注入口。 |
 | `editor.html` | 画布编辑器壳，工具栏、各模式面板、读者浮层、AI 面板、图谱浮层。 |
@@ -113,7 +114,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 ### 根目录选择
 
 - 源码运行时，`ROOT` 是源码目录。
-- PyInstaller 冻结运行时，静态资源来自 `_internal`，用户数据在 exe 同级目录创建。
+- PyInstaller 冻结运行时，静态资源来自 `_internal`。无包身份的 GitHub 便携版仍在 exe 同级创建用户数据；具有 MSIX 包身份的商店版改在 `%LOCALAPPDATA%/Relatum` 创建，不能向只读安装目录写入。
 - `SOURCE_ROOT` 表示源码目录，`RESOURCE_ROOT` 表示源码或 PyInstaller `_internal` 的只读资源目录；运行时静态资产从 `RESOURCE_ROOT/assets` 读取。外部《AI笔记创作指南》不属于运行时资源。
 
 ### 用户数据文件

--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ powershell -ExecutionPolicy Bypass -File .\build-desktop.ps1
 
 输出位于项目同级的 `Relatum-release/`。构建脚本不会把 `data/` 或 `canvases/` 打进发布包。
 
+### 构建 Microsoft Store 包
+
+先安装 Windows 10/11 SDK（需要其中的 `MakeAppx.exe`），然后运行：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\build-msix.ps1
+```
+
+输出位于项目同级的 `Relatum-store/`。向合作伙伴中心上传其中的
+`Relatum_<版本>_x64.msixupload`。商店安装版把画布和设置保存在
+`%LOCALAPPDATA%\Relatum`；源码模式和 GitHub 便携版的数据位置保持不变。
+
 ## 项目结构
 
 ```text
@@ -157,7 +169,8 @@ Relatum/
 ├─ windows_wallpaper.py      隔离的倒数日动态背景子进程、WorkerW 挂载与托盘生命周期
 ├─ assets/                   HTML、CSS、JavaScript 与运行资源
 ├─ packaging/                图标、字体和桌面构建辅助工具
-├─ build-desktop.ps1         Windows 桌面发布包构建入口
+├─ build-desktop.ps1         Windows 便携发布包构建入口
+├─ build-msix.ps1            Microsoft Store MSIX 构建入口
 ├─ start.ps1                 源码模式启动入口
 ├─ AI笔记创作指南.md          外部准备画布/Markdown 笔记的参考（非运行时依赖）
 └─ AGENTS.md                 架构约束与维护说明

--- a/README_EN.md
+++ b/README_EN.md
@@ -148,6 +148,19 @@ powershell -ExecutionPolicy Bypass -File .\build-desktop.ps1
 
 The output is placed in the sibling `Relatum-release/` directory. User `data/` and `canvases/` are never bundled into the release.
 
+### Build the Microsoft Store package
+
+Install the Windows 10/11 SDK (including `MakeAppx.exe`), then run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\build-msix.ps1
+```
+
+The output is placed in the sibling `Relatum-store/` directory. Upload
+`Relatum_<version>_x64.msixupload` to Partner Center. Store installations keep
+canvas and settings data under `%LOCALAPPDATA%\Relatum`; source mode and the
+GitHub portable build retain their existing data locations.
+
 ## Project structure
 
 ```text
@@ -156,7 +169,8 @@ Relatum/
 ├─ desktop.py                Windows desktop shell
 ├─ assets/                   HTML, CSS, JavaScript, and runtime assets
 ├─ packaging/                Icon, font, and desktop build helpers
-├─ build-desktop.ps1         Windows release build entry point
+├─ build-desktop.ps1         Windows portable release build entry point
+├─ build-msix.ps1            Microsoft Store MSIX build entry point
 ├─ start.ps1                 Source-mode launcher
 ├─ AI笔记创作指南.md          External canvas/Markdown authoring reference (not a runtime dependency)
 └─ AGENTS.md                 Architecture and maintenance constraints

--- a/app.py
+++ b/app.py
@@ -42,11 +42,46 @@ from ai_plan import (
     parse_plan,
 )
 
-# 桌面打包版把内置资源放在运行时资源目录，而用户数据必须始终留在
-# EXE 旁边，不能和应用资源混在一起。
+# 桌面打包版把内置资源放在运行时资源目录。便携版用户数据留在 EXE
+# 旁边；具有 MSIX 包身份时改用 %LOCALAPPDATA%\Relatum，避免写只读安装目录。
 SOURCE_ROOT = Path(__file__).resolve().parent
 RESOURCE_ROOT = Path(getattr(sys, "_MEIPASS", SOURCE_ROOT))
-ROOT = Path(sys.executable).resolve().parent if getattr(sys, "frozen", False) else SOURCE_ROOT
+
+
+def _has_package_identity() -> bool:
+    """Return whether this process is running with an MSIX package identity."""
+    if sys.platform != "win32":
+        return False
+    try:
+        import ctypes
+
+        length = ctypes.c_uint32(0)
+        result = ctypes.windll.kernel32.GetCurrentPackageFullName(
+            ctypes.byref(length), None,
+        )
+        return result == 122  # ERROR_INSUFFICIENT_BUFFER: a package name exists.
+    except (AttributeError, OSError):
+        return False
+
+
+def _resolve_user_root(*, packaged: bool | None = None) -> Path:
+    """Choose a writable root without changing portable/source-mode behavior."""
+    override = os.environ.get("RELATUM_DATA_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    is_packaged = _has_package_identity() if packaged is None else packaged
+    if is_packaged:
+        local_app_data = os.environ.get("LOCALAPPDATA", "").strip()
+        if local_app_data:
+            return Path(local_app_data) / "Relatum"
+        return Path.home() / "AppData" / "Local" / "Relatum"
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).resolve().parent
+    return SOURCE_ROOT
+
+
+PACKAGED = _has_package_identity()
+ROOT = _resolve_user_root(packaged=PACKAGED)
 ASSETS = RESOURCE_ROOT / "assets"
 CANVASES = ROOT / "canvases"
 TRASH = CANVASES / "回收站"   # 右键删除 = 移到这里（用户自己管理，可恢复）

--- a/build-msix.ps1
+++ b/build-msix.ps1
@@ -1,0 +1,139 @@
+# Relatum Microsoft Store package builder (x64 MSIX)
+# -----------------------------------------------------------------------------
+# Builds the existing PyInstaller onedir application, stages an AppxManifest,
+# creates the required visual assets, and emits both .msix and .msixupload.
+# The Store accepts the unsigned upload and signs the certified package.
+#
+#   powershell -ExecutionPolicy Bypass -File .\build-msix.ps1
+#   powershell -ExecutionPolicy Bypass -File .\build-msix.ps1 -SkipInstall
+#   powershell -ExecutionPolicy Bypass -File .\build-msix.ps1 -Version 12.4.1.0
+#
+# Requires MakeAppx.exe from the Windows 10/11 SDK.
+# NOTE: keep this script ASCII-only for Windows PowerShell 5.1 compatibility.
+# -----------------------------------------------------------------------------
+param(
+    [ValidatePattern('^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$')]
+    [string]$Version = '12.4.0.0',
+    [switch]$SkipInstall,
+    [switch]$SkipDesktopBuild,
+    [switch]$KeepBuildArtifacts
+)
+
+$ErrorActionPreference = 'Stop'
+$ProjectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ReleaseParent = Split-Path $ProjectRoot -Parent
+$PortableRelease = Join-Path $ReleaseParent 'Relatum-release'
+$OutputRoot = Join-Path $ReleaseParent 'Relatum-store'
+$BuildParent = [System.IO.Path]::GetFullPath($env:TEMP).TrimEnd('\')
+$StageRoot = Join-Path $BuildParent 'relatum-msix-stage'
+$ManifestTemplate = Join-Path $ProjectRoot 'packaging\AppxManifest.xml.in'
+$AssetScript = Join-Path $ProjectRoot 'packaging\make_msix_assets.py'
+$BuildPython = Join-Path (Join-Path $BuildParent 'canvas-desktop-build-venv') 'Scripts\python.exe'
+
+function Assert-NativeSuccess([string]$Step) {
+    if ($LASTEXITCODE -ne 0) { throw ($Step + ' failed (exit ' + $LASTEXITCODE + ').') }
+}
+
+function Remove-TreeInside([string]$Target, [string]$Parent) {
+    if (-not (Test-Path -LiteralPath $Target)) { return }
+    $fullTarget = [System.IO.Path]::GetFullPath($Target).TrimEnd('\')
+    $fullParent = [System.IO.Path]::GetFullPath($Parent).TrimEnd('\')
+    if (-not $fullTarget.StartsWith($fullParent + '\', [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw ('Refusing to remove path outside expected parent: ' + $fullTarget)
+    }
+    Remove-Item -LiteralPath $fullTarget -Recurse -Force
+}
+
+function Find-WindowsSdkTool([string]$Leaf) {
+    $command = Get-Command $Leaf -ErrorAction SilentlyContinue
+    if ($command) { return $command.Source }
+    $installedRoot = (Get-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots' -Name KitsRoot10 -ErrorAction SilentlyContinue).KitsRoot10
+    $roots = @(
+        $(if ($installedRoot) { Join-Path $installedRoot 'bin' }),
+        (Join-Path ${env:ProgramFiles(x86)} 'Windows Kits\10\bin'),
+        (Join-Path $env:ProgramFiles 'Windows Kits\10\bin')
+    ) | Where-Object { $_ } | Select-Object -Unique
+    foreach ($root in $roots) {
+        if (-not (Test-Path -LiteralPath $root)) { continue }
+        $candidates = Get-ChildItem -LiteralPath $root -Directory | Sort-Object Name -Descending
+        foreach ($candidate in $candidates) {
+            $tool = Join-Path $candidate.FullName ('x64\' + $Leaf)
+            if (Test-Path -LiteralPath $tool) { return $tool }
+        }
+    }
+    return $null
+}
+
+$versionParts = $Version.Split('.')
+foreach ($part in $versionParts) {
+    if ([int]$part -gt 65535) { throw ('MSIX version component exceeds 65535: ' + $Version) }
+}
+
+if (-not $SkipDesktopBuild) {
+    $desktopArgs = @()
+    if ($SkipInstall) { $desktopArgs += '-SkipInstall' }
+    if ($KeepBuildArtifacts) { $desktopArgs += '-KeepBuildArtifacts' }
+    & (Join-Path $ProjectRoot 'build-desktop.ps1') @desktopArgs
+}
+
+$ReleaseExe = Join-Path $PortableRelease 'Relatum.exe'
+if (-not (Test-Path -LiteralPath $ReleaseExe)) {
+    throw ('Portable build output is missing: ' + $ReleaseExe)
+}
+if ((Test-Path -LiteralPath (Join-Path $PortableRelease 'canvases')) -or
+    (Test-Path -LiteralPath (Join-Path $PortableRelease 'data'))) {
+    throw ('Portable build contains user data and cannot be packaged: ' + $PortableRelease)
+}
+if (-not (Test-Path -LiteralPath $ManifestTemplate)) {
+    throw ('MSIX manifest template is missing: ' + $ManifestTemplate)
+}
+if (-not (Test-Path -LiteralPath $AssetScript)) {
+    throw ('MSIX asset generator is missing: ' + $AssetScript)
+}
+if (-not (Test-Path -LiteralPath $BuildPython)) {
+    throw ('Build Python is missing. Run without -SkipDesktopBuild first: ' + $BuildPython)
+}
+
+$MakeAppx = Find-WindowsSdkTool 'MakeAppx.exe'
+if (-not $MakeAppx) {
+    throw 'MakeAppx.exe was not found. Install the Windows 10/11 SDK, then rerun this script.'
+}
+
+Remove-TreeInside $StageRoot $BuildParent
+New-Item -ItemType Directory -Path $StageRoot | Out-Null
+Copy-Item -Path (Join-Path $PortableRelease '*') -Destination $StageRoot -Recurse -Force
+
+$Manifest = (Get-Content -LiteralPath $ManifestTemplate -Raw).Replace('__VERSION__', $Version)
+[System.IO.File]::WriteAllText(
+    (Join-Path $StageRoot 'AppxManifest.xml'),
+    $Manifest,
+    [System.Text.UTF8Encoding]::new($false)
+)
+& $BuildPython $AssetScript (Join-Path $StageRoot 'Assets')
+Assert-NativeSuccess 'Generating MSIX visual assets'
+
+if (-not (Test-Path -LiteralPath $OutputRoot)) {
+    New-Item -ItemType Directory -Path $OutputRoot | Out-Null
+}
+$BaseName = 'Relatum_' + $Version + '_x64'
+$MsixPath = Join-Path $OutputRoot ($BaseName + '.msix')
+$UploadPath = Join-Path $OutputRoot ($BaseName + '.msixupload')
+$UploadZip = Join-Path $OutputRoot ($BaseName + '.zip')
+foreach ($target in @($MsixPath, $UploadPath, $UploadZip)) {
+    if (Test-Path -LiteralPath $target) { Remove-Item -LiteralPath $target -Force }
+}
+
+& $MakeAppx pack /v /h SHA256 /d $StageRoot /p $MsixPath
+Assert-NativeSuccess 'Creating MSIX package'
+
+Compress-Archive -LiteralPath $MsixPath -DestinationPath $UploadZip -CompressionLevel Optimal
+Move-Item -LiteralPath $UploadZip -Destination $UploadPath
+
+if (-not (Test-Path -LiteralPath $MsixPath)) { throw ('MSIX output missing: ' + $MsixPath) }
+if (-not (Test-Path -LiteralPath $UploadPath)) { throw ('MSIX upload output missing: ' + $UploadPath) }
+if (-not $KeepBuildArtifacts) { Remove-TreeInside $StageRoot $BuildParent }
+
+Write-Host ''
+Write-Host ('MSIX package complete: ' + $MsixPath)
+Write-Host ('Partner Center upload: ' + $UploadPath)
+Write-Host 'Upload the .msixupload file on the Package page.'

--- a/desktop.py
+++ b/desktop.py
@@ -744,7 +744,10 @@ def main() -> int:
 
     try:
         local = os.environ.get("LOCALAPPDATA")
-        storage = (Path(local) / "Canvas" / "WebView2") if local else (app.DATA / "webview")
+        if app.PACKAGED:
+            storage = app.ROOT / "WebView2"
+        else:
+            storage = (Path(local) / "Canvas" / "WebView2") if local else (app.DATA / "webview")
         storage.mkdir(parents=True, exist_ok=True)
         _apply_webview_cache_limits()
         icon = app.ASSETS / "app-icon.ico"

--- a/packaging/AppxManifest.xml.in
+++ b/packaging/AppxManifest.xml.in
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap uap10 rescap">
+
+  <Identity
+    Name="Imitationcry.Relatum"
+    Publisher="CN=DB4CDC8D-BA7B-416E-85AB-1B0F20ABAE66"
+    Version="__VERSION__"
+    ProcessorArchitecture="x64" />
+
+  <Properties>
+    <DisplayName>Relatum</DisplayName>
+    <PublisherDisplayName>Imitationcry</PublisherDisplayName>
+    <Description>Local-first knowledge canvas and learning workspace.</Description>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+
+  <Resources>
+    <Resource Language="zh-CN" />
+  </Resources>
+
+  <Dependencies>
+    <TargetDeviceFamily
+      Name="Windows.Desktop"
+      MinVersion="10.0.19041.0"
+      MaxVersionTested="10.0.26100.0" />
+  </Dependencies>
+
+  <Applications>
+    <Application
+      Id="Relatum"
+      Executable="Relatum.exe"
+      uap10:RuntimeBehavior="packagedClassicApp"
+      uap10:TrustLevel="mediumIL">
+      <uap:VisualElements
+        DisplayName="Relatum"
+        Description="Local-first knowledge canvas and learning workspace."
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
+      </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.fileTypeAssociation">
+          <uap:FileTypeAssociation Name="relatum-canvas">
+            <uap:DisplayName>Relatum Canvas</uap:DisplayName>
+            <uap:SupportedFileTypes>
+              <uap:FileType>.canvas</uap:FileType>
+            </uap:SupportedFileTypes>
+          </uap:FileTypeAssociation>
+        </uap:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>

--- a/packaging/make_msix_assets.py
+++ b/packaging/make_msix_assets.py
@@ -1,0 +1,41 @@
+"""Generate the exact PNG asset sizes referenced by AppxManifest.xml."""
+from pathlib import Path
+
+from PIL import Image
+
+
+PACKAGING = Path(__file__).resolve().parent
+SOURCE = PACKAGING / "icon-source.png"
+
+
+def contain(source: Image.Image, size: tuple[int, int], icon_size: int) -> Image.Image:
+    canvas = Image.new("RGBA", size, (0, 0, 0, 0))
+    icon = source.copy()
+    icon.thumbnail((icon_size, icon_size), Image.Resampling.LANCZOS)
+    position = ((size[0] - icon.width) // 2, (size[1] - icon.height) // 2)
+    canvas.alpha_composite(icon, position)
+    return canvas
+
+
+def main(output: Path) -> None:
+    if not SOURCE.is_file():
+        raise FileNotFoundError(f"Icon source is missing: {SOURCE}")
+    output.mkdir(parents=True, exist_ok=True)
+    source = Image.open(SOURCE).convert("RGBA")
+    assets = {
+        "StoreLogo.png": ((50, 50), 50),
+        "Square44x44Logo.png": ((44, 44), 44),
+        "Square150x150Logo.png": ((150, 150), 150),
+        "Wide310x150Logo.png": ((310, 150), 120),
+    }
+    for name, (size, icon_size) in assets.items():
+        contain(source, size, icon_size).save(output / name, optimize=True)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    main(args.output)

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import app
+
+
+class RuntimePathTests(unittest.TestCase):
+    def test_msix_uses_local_app_data(self):
+        local_app_data = (Path.cwd() / "test-local-app-data").resolve()
+        with mock.patch.dict(os.environ, {"LOCALAPPDATA": str(local_app_data)}, clear=False):
+            self.assertEqual(
+                app._resolve_user_root(packaged=True),
+                local_app_data / "Relatum",
+            )
+
+    def test_explicit_root_override_wins(self):
+        override = Path.cwd() / "custom-relatum-data"
+        with mock.patch.dict(os.environ, {"RELATUM_DATA_ROOT": str(override)}, clear=False):
+            self.assertEqual(app._resolve_user_root(packaged=True), override.resolve())
+
+    def test_source_mode_keeps_repository_root(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("RELATUM_DATA_ROOT", None)
+            with mock.patch.object(app.sys, "frozen", False, create=True):
+                self.assertEqual(app._resolve_user_root(packaged=False), app.SOURCE_ROOT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a reproducible x64 MSIX and `.msixupload` build pipeline for Microsoft Store
- add the reserved Store identity, desktop manifest, `.canvas` file association, and generated Store assets
- detect MSIX package identity and store writable user data under `%LOCALAPPDATA%\Relatum`
- preserve existing source-mode and GitHub portable-build data locations
- document the Store build workflow and add runtime-path regression tests

## Why

MSIX installs application binaries in a protected, read-only location. Relatum previously treated the executable directory as its writable data root, so Store installations needed a separate writable-data policy and a Store-compatible package workflow.

## User impact

Microsoft Store installations now keep canvases, attachments, settings, and databases in `%LOCALAPPDATA%\Relatum`. Existing portable users continue using the folders next to `Relatum.exe` without migration or behavior changes.

## Validation

- `python -m unittest discover -s tests -p 'test_*.py'` — 65 tests passed
- Python compilation checks — passed
- public repository safety check — passed
- PyInstaller desktop build — passed
- MakeAppx pack/unpack validation — passed (522 packaged files)
- verified package identity `Imitationcry.Relatum`, x64 version `12.4.0.0`
- verified no `data/` or `canvases/` directories leaked into the package
