### PR TITLE
Add cumulative daily goals and milestones

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,6 +40,12 @@ jobs:
             Where-Object { $_.FullName -notmatch '\\vendor\\' } |
             ForEach-Object { node --check $_.FullName }
 
+      - name: Run daily goal tests
+        shell: pwsh
+        run: |
+          python -m unittest tests.test_daily_goals
+          node tests/daily-goal-contract.js
+
       - name: Run rich-text regression tests
         shell: pwsh
         run: node tests/richtext-regression.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 | 起步页跨页便签 | `data/start-sticky-notes.json`，按 `recent/study/cadence/calendar/review/focus` 页面归属保存；不进入速记墙归档 |
 | 速记归档 | `data/学习归档/<时间>-速记归档/notes.json` |
 | 专注记录 | `data/focus.json` |
-| 每日任务 | `data/daily.json`，含汇总字段与逐日历史 `doneDates` / `minutesByDate` |
+| 每日任务 | `data/daily.json`，含汇总字段、可选累计打卡目标 `targetDays`、至多 6 个命名里程碑 `milestones[]` 与逐日历史 `doneDates` / `minutesByDate` |
 | 日记 | `data/diary/YYYY-MM-DD.md` |
 | 日历任务便签 | `data/calendar-pins.json` |
 | 倒数日 | `data/countdown.json`，v2 为 `events[] + selectedId`，并镜像当前 `event/date`；允许零事件，零事件时文件不存在；旧版单事件自动兼容迁移 |
@@ -438,7 +438,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 - 支持番茄钟和正计时，运行状态存在 `localStorage`，刷新后可恢复。
 - 可绑定学习任务或每日任务。专注完成后写入 `data/focus.json`，并同步任务统计。
 - 支持音效、柔和噪音、时长偏好、目标/收尾记录、记录编辑/删除、Zen 模式。
-- 每日任务是独立清单 `data/daily.json`，每天重置勾选状态，但累计天数和分钟保留；v3 起每条任务记录 `doneDates` / `minutesByDate`，用于专注页任务打卡日历。
+- 每日任务是独立清单 `data/daily.json`，每天重置勾选状态，但累计天数和分钟保留；v3 起每条任务记录 `doneDates` / `minutesByDate`，用于专注页任务打卡日历，并可用 `targetDays` 设置基于历史 `totalDays` 的累计打卡目标（`0` 表示未设置，上限 3660 天）。可选 `milestones:[{id,name,days}]` 保存至多 6 个命名小目标，天数必须唯一且位于 `1..targetDays`，达成态只由 `totalDays >= days` 推导；高级设置先写任务编辑草稿，最后与总目标一起经 `/api/daily-update` 原子保存。任务卡和详情长期进度条以非按钮圆印章显示节点，悬停/键盘聚焦显示即时说明，桌面点击无操作、触屏轻触只揭示说明；今日分钟目标仍保留在编辑器与详情面板。
 - 每日任务详情标题保留单行省略号，但行盒必须给中英文及拉丁字母上下伸部留足空间，短标题也不能被纵向裁切。
 - `pagehide` 会持久化运行态、停 ticker 并暂停 AudioContext；BFCache `pageshow` 会按保存时间补算经过秒数、恢复 ticker/显示和需要继续播放的噪音。
 

--- a/app.py
+++ b/app.py
@@ -2646,11 +2646,14 @@ def delete_focus_session(session_id: object) -> dict:
 # ── 专注页「每日任务」习惯清单 ─────────────────────────────
 # 自成一体：每天重置勾选，累计完成天数/连续天数/累计专注分钟；不进 .canvas、与学习任务解耦。
 # 数据存 data/daily.json：{version, date(每日状态所属自然日), tasks:[...]}。
-# v3 起每条任务补 doneDates / minutesByDate，供打卡日历使用；旧汇总字段继续保留。
+# v3 起每条任务补 doneDates / minutesByDate，供打卡日历使用；可选 targetDays / milestones 保存长期累计目标；旧汇总字段继续保留。
 DAILY_TASKS_MAX = 40           # 上限保护，避免清单无限膨胀
 DAILY_NAME_MAX = 80
 DAILY_TARGET_MAX = 600
 DAILY_HISTORY_MAX = 3660       # 单任务最多保留约 10 年逐日记录
+DAILY_GOAL_DAYS_MAX = 3660     # 累计打卡目标上限，与逐日历史的十年保护边界一致
+DAILY_MILESTONES_MAX = 6
+DAILY_MILESTONE_NAME_MAX = 40
 DAILY_GROUPS_MAX = 60          # 分组数量上限（与任务上限分开计）
 DAILY_GROUP_NAME_MAX = 60
 DAILY_DEPTH_MAX = 12           # 分组嵌套层级安全上限（够深，主要防御成环/失控缩进）
@@ -2738,6 +2741,89 @@ def _daily_best_streak(done_dates: list[str]) -> int:
     return best
 
 
+def _sanitize_daily_milestones(value: object, target_days: int) -> list[dict]:
+    """加载旧数据或损坏数据时尽量保留合法里程碑。"""
+    if not isinstance(value, list) or target_days <= 0:
+        return []
+    result: list[dict] = []
+    seen_days: set[int] = set()
+    seen_ids: set[str] = set()
+    for index, item in enumerate(value):
+        if len(result) >= DAILY_MILESTONES_MAX:
+            break
+        if not isinstance(item, dict):
+            continue
+        name = (item.get("name") if isinstance(item.get("name"), str) else "").strip()
+        days = _daily_nat(item.get("days"))
+        if not name or days < 1 or days > target_days or days in seen_days:
+            continue
+        mid = (item.get("id") if isinstance(item.get("id"), str) else "").strip()[:64]
+        if not mid or mid in seen_ids:
+            mid = f"dm_{days:x}_{index + 1:x}"
+            suffix = 1
+            while mid in seen_ids:
+                suffix += 1
+                mid = f"dm_{days:x}_{index + 1:x}_{suffix:x}"
+        seen_days.add(days)
+        seen_ids.add(mid)
+        result.append({"id": mid, "name": name[:DAILY_MILESTONE_NAME_MAX], "days": days})
+    result.sort(key=lambda item: item["days"])
+    return result
+
+
+def _validate_daily_milestones(value: object, target_days: int) -> list[dict]:
+    """校验客户端提交的完整数组；任一项有误都拒绝整次原子更新。"""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("小目标格式不正确")
+    if len(value) > DAILY_MILESTONES_MAX:
+        raise ValueError(f"小目标最多 {DAILY_MILESTONES_MAX} 个")
+    if value and target_days <= 0:
+        raise ValueError("请先设置累计目标，再添加小目标")
+    result: list[dict] = []
+    seen_days: set[int] = set()
+    seen_ids: set[str] = set()
+    for index, item in enumerate(value):
+        label = f"第 {index + 1} 个小目标"
+        if not isinstance(item, dict):
+            raise ValueError(f"{label}格式不正确")
+        raw_name = item.get("name")
+        name = raw_name.strip() if isinstance(raw_name, str) else ""
+        if not name:
+            raise ValueError(f"请填写{label}的名称")
+        if len(name) > DAILY_MILESTONE_NAME_MAX:
+            raise ValueError(f"{label}名称不能超过 {DAILY_MILESTONE_NAME_MAX} 个字符")
+        raw_days = item.get("days")
+        if isinstance(raw_days, bool):
+            raise ValueError(f"{label}的天数必须是正整数")
+        if isinstance(raw_days, int):
+            days = raw_days
+        elif isinstance(raw_days, str) and re.fullmatch(r"[0-9]+", raw_days.strip()):
+            days = int(raw_days.strip())
+        else:
+            raise ValueError(f"{label}的天数必须是正整数")
+        if days < 1:
+            raise ValueError(f"{label}的天数必须至少为 1")
+        if days > target_days:
+            raise ValueError(f"{label}（{days} 天）不能超过累计目标 {target_days} 天")
+        if days in seen_days:
+            raise ValueError(f"不能在第 {days} 天设置两个小目标")
+        raw_id = item.get("id")
+        mid = raw_id.strip() if isinstance(raw_id, str) else ""
+        if len(mid) > 64:
+            raise ValueError(f"{label}标识无效")
+        if not mid:
+            mid = "dm_" + uuid.uuid4().hex[:16]
+        if mid in seen_ids:
+            raise ValueError("小目标标识重复")
+        seen_days.add(days)
+        seen_ids.add(mid)
+        result.append({"id": mid, "name": name, "days": days})
+    result.sort(key=lambda item: item["days"])
+    return result
+
+
 def _sanitize_daily_task(item: object) -> dict | None:
     """把一条每日任务规范化成可信结构；非法直接丢弃（返回 None）。"""
     if not isinstance(item, dict):
@@ -2752,10 +2838,13 @@ def _sanitize_daily_task(item: object) -> dict | None:
     if last_done and last_done not in done_dates:
         done_dates.append(last_done)
         done_dates.sort()
+    target_days = min(_daily_nat(item.get("targetDays")), DAILY_GOAL_DAYS_MAX)
     task = {
         "id": tid[:64],
         "name": (item.get("name") if isinstance(item.get("name"), str) else "").strip()[:DAILY_NAME_MAX],
         "targetMinutes": min(_daily_nat(item.get("targetMinutes")), DAILY_TARGET_MAX),
+        "targetDays": target_days,
+        "milestones": _sanitize_daily_milestones(item.get("milestones"), target_days),
         "totalDays": _daily_nat(item.get("totalDays")),
         "streak": _daily_nat(item.get("streak")),
         "bestStreak": _daily_nat(item.get("bestStreak")),
@@ -2920,6 +3009,8 @@ def daily_public_payload(data: dict | None = None) -> dict:
             "id": task.get("id"),
             "name": task.get("name") or "",
             "targetMinutes": _daily_nat(task.get("targetMinutes")),
+            "targetDays": min(_daily_nat(task.get("targetDays")), DAILY_GOAL_DAYS_MAX),
+            "milestones": [dict(item) for item in task.get("milestones", [])],
             "totalDays": _daily_nat(task.get("totalDays")),
             "streak": _daily_nat(task.get("streak")),
             "bestStreak": _daily_nat(task.get("bestStreak")),
@@ -2948,11 +3039,15 @@ def daily_create(body: dict) -> dict:
     if not name:
         raise ValueError("请填写每日任务名称")
     target = min(_daily_nat(body.get("targetMinutes")), DAILY_TARGET_MAX)
+    target_days = min(_daily_nat(body.get("targetDays")), DAILY_GOAL_DAYS_MAX)
+    milestones = _validate_daily_milestones(body.get("milestones", []), target_days)
     group_id = _daily_valid_group_id(data, body.get("groupId") if isinstance(body, dict) else "")
     task = {
         "id": "dt_" + format(int(datetime.now().timestamp() * 1000), "x") + "_" + uuid.uuid4().hex[:3],
         "name": name,
         "targetMinutes": target,
+        "targetDays": target_days,
+        "milestones": milestones,
         "totalDays": 0,
         "streak": 0,
         "bestStreak": 0,
@@ -2972,13 +3067,24 @@ def daily_create(body: dict) -> dict:
 def daily_update(body: dict) -> dict:
     data = load_daily()
     task = _daily_find(data, str(body.get("id") or "").strip() if isinstance(body, dict) else "")
+    next_name = task.get("name") or ""
     if "name" in body:
         name = str(body.get("name") or "").strip()[:DAILY_NAME_MAX]
         if not name:
             raise ValueError("名称不能为空")
-        task["name"] = name
+        next_name = name
+    next_target_minutes = task.get("targetMinutes", 0)
     if "targetMinutes" in body:
-        task["targetMinutes"] = min(_daily_nat(body.get("targetMinutes")), DAILY_TARGET_MAX)
+        next_target_minutes = min(_daily_nat(body.get("targetMinutes")), DAILY_TARGET_MAX)
+    next_target_days = min(_daily_nat(task.get("targetDays")), DAILY_GOAL_DAYS_MAX)
+    if "targetDays" in body:
+        next_target_days = min(_daily_nat(body.get("targetDays")), DAILY_GOAL_DAYS_MAX)
+    milestone_source = body.get("milestones") if "milestones" in body else task.get("milestones", [])
+    next_milestones = _validate_daily_milestones(milestone_source, next_target_days)
+    task["name"] = next_name
+    task["targetMinutes"] = next_target_minutes
+    task["targetDays"] = next_target_days
+    task["milestones"] = next_milestones
     if "groupId" in body:
         task["groupId"] = _daily_valid_group_id(data, body.get("groupId"))
     save_daily(data)

--- a/assets/focus.js
+++ b/assets/focus.js
@@ -115,6 +115,11 @@
   let dailyLoaded = false;
   let dailyOpen = false;
   let dailyEditId = '';
+  let dailyEditMilestones = null;
+  let dailyMilestoneDialog = null;
+  let dailyMilestoneDialogDraft = [];
+  let dailyMilestoneReturnEl = null;
+  let dailyMilestoneTipSeq = 0;
   let dailyConfirmDeleteId = '';  // 删除二次确认：编辑器内就地变「确认删除？」，不弹原生 confirm
   let dailyGroupEditId = '';      // 正在展开菜单/改名的分组 id
   let dailyGroupConfirmDeleteId = '';
@@ -1710,6 +1715,144 @@
     if (!(Number(task.targetMinutes) > 0) && today > 0) parts.push(T('今天 ' + today + ' 分'));
     return parts.length ? parts.join(' · ') : T('今天还没开始');
   }
+  function dailyGoalState(task) {
+    const target = Math.max(0, Math.min(3660, Number(task && task.targetDays) || 0));
+    const total = Math.max(0, Number(task && task.totalDays) || 0);
+    return {
+      target: target,
+      total: total,
+      progress: target > 0 ? Math.max(0, Math.min(1, total / target)) : 0,
+      reached: target > 0 && total >= target,
+    };
+  }
+  function dailyGoalProgressText(task) {
+    const goal = dailyGoalState(task);
+    if (!goal.target) return '';
+    return T('累计 ' + goal.total + ' / ' + goal.target + ' 天' + (goal.reached ? ' · 已达成' : ''));
+  }
+  function dailyMilestoneList(task) {
+    const goal = dailyGoalState(task);
+    const seen = new Set();
+    return (Array.isArray(task && task.milestones) ? task.milestones : [])
+      .filter((item) => {
+        const days = Number(item && item.days);
+        const name = typeof (item && item.name) === 'string' ? item.name.trim() : '';
+        if (!name || !Number.isInteger(days) || days < 1 || days > goal.target || seen.has(days)) return false;
+        seen.add(days);
+        return true;
+      })
+      .slice(0, 6)
+      .map((item, index) => ({
+        id: String(item.id || ('dm_' + item.days + '_' + index)),
+        name: item.name.trim(),
+        days: Number(item.days),
+      }))
+      .sort((a, b) => a.days - b.days);
+  }
+  function dailyMilestoneText(milestone, reached) {
+    return milestone.name + ' · ' + T('累计目标') + ' ' + milestone.days + T('天')
+      + ' · ' + T(reached ? '已达成' : '未达成');
+  }
+  function dailyMilestoneLanes(milestones, target) {
+    const lanes = [[], [], []];
+    return milestones.map((milestone) => {
+      const position = target > 0 ? Math.max(0, Math.min(100, milestone.days / target * 100)) : 0;
+      let lane = lanes.findIndex((positions) => positions.every((value) => Math.abs(value - position) >= 4.5));
+      if (lane < 0) lane = lanes.reduce((best, positions, index) => positions.length < lanes[best].length ? index : best, 0);
+      lanes[lane].push(position);
+      return { milestone: milestone, position: position, lane: [0, -1, 1][lane] };
+    });
+  }
+  function syncDailyMilestones(shell, task, options) {
+    const layer = shell && shell.querySelector('[data-role="daily-goal-milestones"]');
+    if (!layer) return;
+    const opts = options || {};
+    const goal = dailyGoalState(task);
+    const crossed = new Set(Array.isArray(opts.milestoneIds) ? opts.milestoneIds : []);
+    const layout = dailyMilestoneLanes(dailyMilestoneList(task), goal.target);
+    const keep = new Set(layout.map((entry) => entry.milestone.id));
+    layer.querySelectorAll('.focus-daily-milestone').forEach((marker) => {
+      if (keep.has(marker.dataset.milestoneId)) return;
+      if (prefersReduced) marker.remove();
+      else {
+        marker.classList.add('is-leaving');
+        window.setTimeout(() => marker.remove(), 220);
+      }
+    });
+    layout.forEach((entry) => {
+      const milestone = entry.milestone;
+      const reached = goal.total >= milestone.days;
+      let marker = Array.prototype.find.call(layer.children, (item) => item.dataset.milestoneId === milestone.id);
+      if (!marker) {
+        marker = document.createElement('span');
+        marker.className = 'focus-daily-milestone is-entering';
+        marker.dataset.milestoneId = milestone.id;
+        marker.tabIndex = 0;
+        marker.setAttribute('role', 'img');
+        const stamp = document.createElement('span');
+        stamp.className = 'focus-daily-milestone-stamp';
+        stamp.setAttribute('aria-hidden', 'true');
+        const tip = document.createElement('span');
+        tip.className = 'focus-daily-milestone-tip';
+        tip.setAttribute('role', 'tooltip');
+        dailyMilestoneTipSeq += 1;
+        tip.id = 'daily-milestone-tip-' + dailyMilestoneTipSeq;
+        marker.setAttribute('aria-describedby', tip.id);
+        marker.append(stamp, tip);
+        layer.appendChild(marker);
+        if (!prefersReduced) window.setTimeout(() => marker.classList.remove('is-entering'), 260);
+        else marker.classList.remove('is-entering');
+      }
+      const text = dailyMilestoneText(milestone, reached);
+      marker.style.setProperty('--milestone-position', entry.position.toFixed(3) + '%');
+      marker.style.setProperty('--milestone-lane', String(entry.lane));
+      marker.classList.toggle('is-edge-start', entry.position < 12);
+      marker.classList.toggle('is-edge-end', entry.position > 88);
+      marker.classList.toggle('is-reached', reached);
+      marker.setAttribute('aria-label', text);
+      marker.querySelector('.focus-daily-milestone-tip').textContent = text;
+      if (crossed.has(milestone.id) && !prefersReduced) replayClass(marker, 'is-just-reached');
+    });
+  }
+  function syncDailyGoalProgress(shell, task, options) {
+    if (!shell) return;
+    const opts = options || {};
+    const goal = dailyGoalState(task);
+    const text = dailyGoalProgressText(task);
+    const bar = shell.querySelector('[data-role="daily-goal-track"]');
+    const fill = shell.querySelector('[data-role="daily-goal-fill"]');
+    if (!bar) return;
+    bar.setAttribute('aria-valuemin', '0');
+    bar.setAttribute('aria-valuemax', String(goal.target));
+    bar.setAttribute('aria-valuenow', String(Math.min(goal.total, goal.target)));
+    bar.setAttribute('aria-valuetext', text);
+    bar.setAttribute('data-ui-tooltip', text);
+    bar.classList.toggle('is-full', goal.reached);
+    if (fill) fill.style.width = (goal.progress * 100).toFixed(2) + '%';
+    if (opts.glow && !prefersReduced) {
+      replayClass(bar, opts.reached ? 'is-goal-reached' : 'is-advancing');
+    }
+    syncDailyMilestones(shell, task, opts);
+  }
+  function buildDailyGoalProgress(task, className) {
+    const shell = document.createElement('div');
+    shell.className = 'focus-daily-goal-shell';
+    const bar = document.createElement('div');
+    bar.className = (className || 'focus-daily-goal') + ' focus-daily-goal-track';
+    bar.dataset.role = 'daily-goal-track';
+    bar.setAttribute('role', 'progressbar');
+    bar.setAttribute('aria-label', T('累计打卡目标'));
+    const fill = document.createElement('span');
+    fill.className = 'focus-daily-goal-fill';
+    fill.dataset.role = 'daily-goal-fill';
+    bar.appendChild(fill);
+    const markers = document.createElement('div');
+    markers.className = 'focus-daily-milestones';
+    markers.dataset.role = 'daily-goal-milestones';
+    shell.append(bar, markers);
+    syncDailyGoalProgress(shell, task);
+    return shell;
+  }
   function dailyDoneDateSet(task) {
     return new Set(Array.isArray(task && task.doneDates) ? task.doneDates : []);
   }
@@ -2028,6 +2171,7 @@
     const todayMinutes = Number(task.todayMinutes) || 0;
     const target = Number(task.targetMinutes) || 0;
     const totalMinutes = Number(task.totalMinutes) || 0;
+    const dayGoal = dailyGoalState(task);
     const recorded = doneDates.size;
     const group = task.groupId ? dailyGroupById(task.groupId) : null;
     const groupLabel = group ? dailyGroupPathLabel(group) : T('未分组');
@@ -2161,6 +2305,17 @@
 
     const side = document.createElement('aside');
     side.className = 'focus-daily-detail-side';
+    if (dayGoal.target > 0) {
+      const goalBlock = dailyDetailBlock(T('累计目标'));
+      const goalText = document.createElement('p');
+      goalText.className = 'focus-daily-detail-progress-text';
+      goalText.dataset.role = 'daily-detail-goal-text';
+      goalText.textContent = dailyGoalProgressText(task);
+      goalBlock.appendChild(goalText);
+      const goalBar = buildDailyGoalProgress(task, 'focus-daily-detail-progress is-cumulative');
+      goalBlock.appendChild(goalBar);
+      side.appendChild(goalBlock);
+    }
     const progressBlock = dailyDetailBlock('今日进度');
     const progressText = document.createElement('p');
     progressText.className = 'focus-daily-detail-progress-text';
@@ -2248,22 +2403,7 @@
     stat.textContent = dailyStatText(task);
     main.appendChild(stat);
 
-    const target = Number(task.targetMinutes) || 0;
-    if (target > 0) {
-      const today = Number(task.todayMinutes) || 0;
-      const lab = document.createElement('div');
-      lab.className = 'focus-daily-bar-label';
-      lab.textContent = '今天 ' + today + ' / ' + target + ' 分' + (today >= target ? ' · 达标 ✦' : '');
-      main.appendChild(lab);
-      const bar = document.createElement('div');
-      bar.className = 'focus-daily-bar';
-      const fill = document.createElement('span');
-      const pct = Math.max(0, Math.min(1, today / target));
-      fill.style.width = (pct * 100).toFixed(0) + '%';
-      if (pct >= 1) fill.classList.add('is-full');
-      bar.appendChild(fill);
-      main.appendChild(bar);
-    }
+    if (dailyGoalState(task).target > 0) main.appendChild(buildDailyGoalProgress(task));
 
     if (dailyEditId === task.id) main.appendChild(buildDailyEditor(task));
     row.appendChild(main);
@@ -2332,6 +2472,41 @@
     targetIn.placeholder = '分钟 · 可选';
     targetIn.value = Number(task.targetMinutes) > 0 ? String(task.targetMinutes) : '';
     targetWrap.append(tspan, targetIn);
+    const goalWrap = document.createElement('div');
+    goalWrap.className = 'focus-daily-edit-target';
+    const goalField = document.createElement('label');
+    goalField.className = 'focus-daily-edit-target-field';
+    const goalSpan = document.createElement('span');
+    goalSpan.textContent = T('累计目标');
+    const goalIn = document.createElement('input');
+    goalIn.type = 'number';
+    goalIn.min = '0';
+    goalIn.max = '3660';
+    goalIn.step = '1';
+    goalIn.className = 'focus-daily-edit-days';
+    goalIn.dataset.role = 'daily-edit-days';
+    goalIn.placeholder = T('天 · 可选');
+    goalIn.setAttribute('aria-label', T('累计打卡目标天数'));
+    goalIn.value = Number(task.targetDays) > 0 ? String(task.targetDays) : '';
+    const advanced = document.createElement('button');
+    advanced.type = 'button';
+    advanced.className = 'focus-daily-edit-advanced';
+    advanced.dataset.role = 'daily-edit-advanced';
+    advanced.textContent = T('高级设置');
+    advanced.setAttribute('aria-haspopup', 'dialog');
+    const updateAdvanced = () => {
+      const value = Number(goalIn.value);
+      const enabled = Number.isInteger(value) && value > 0 && value <= 3660;
+      advanced.disabled = !enabled;
+      advanced.setAttribute('aria-disabled', enabled ? 'false' : 'true');
+      advanced.setAttribute('data-ui-tooltip', enabled ? T('设置累计小目标') : T('请先设置累计目标'));
+      const count = Array.isArray(dailyEditMilestones) ? dailyEditMilestones.length : 0;
+      advanced.textContent = T('高级设置') + (count ? ' · ' + count + '/6' : '');
+    };
+    goalIn.addEventListener('input', updateAdvanced);
+    goalField.append(goalSpan, goalIn);
+    goalWrap.append(goalField, advanced);
+    updateAdvanced();
     const actions = document.createElement('div');
     actions.className = 'focus-daily-edit-actions';
     const del = document.createElement('button');
@@ -2346,9 +2521,214 @@
     save.textContent = '完成';
     actions.append(del, save);
     const groupRow = buildDailyGroupSelect(task);
-    if (groupRow) box.append(nameIn, targetWrap, groupRow, actions);
-    else box.append(nameIn, targetWrap, actions);
+    if (groupRow) box.append(nameIn, targetWrap, goalWrap, groupRow, actions);
+    else box.append(nameIn, targetWrap, goalWrap, actions);
     return box;
+  }
+  function cloneDailyMilestones(items) {
+    return (Array.isArray(items) ? items : []).slice(0, 6).map((item, index) => ({
+      id: String(item && item.id || ('dm_draft_' + Date.now().toString(36) + '_' + index)),
+      name: String(item && item.name || ''),
+      days: Number(item && item.days) || 0,
+    }));
+  }
+  function dailyMilestoneDraftId() {
+    return 'dm_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 9);
+  }
+  function dailyEditTargetDays(id) {
+    const row = dailyListEl && dailyListEl.querySelector('.focus-daily-row[data-id="' + id + '"]');
+    const input = row && row.querySelector('[data-role="daily-edit-days"]');
+    const value = Number(input && input.value);
+    return Number.isInteger(value) && value > 0 && value <= 3660 ? value : 0;
+  }
+  function setDailyMilestoneDialogError(message) {
+    if (!dailyMilestoneDialog) return;
+    const error = dailyMilestoneDialog.querySelector('[data-role="daily-milestone-error"]');
+    if (error) error.textContent = message || '';
+  }
+  function updateDailyMilestoneAddState() {
+    if (!dailyMilestoneDialog) return;
+    const count = dailyMilestoneDialog.querySelectorAll('.focus-daily-milestone-row:not(.is-leaving)').length;
+    const add = dailyMilestoneDialog.querySelector('[data-action="daily-milestone-add"]');
+    if (add) {
+      add.disabled = count >= 6;
+      add.textContent = count >= 6 ? T('已达到 6 个上限') : T('添加小目标') + ' · ' + count + '/6';
+    }
+  }
+  function appendDailyMilestoneDraftRow(item, animate) {
+    if (!dailyMilestoneDialog) return null;
+    const list = dailyMilestoneDialog.querySelector('[data-role="daily-milestone-list"]');
+    if (!list) return null;
+    const row = document.createElement('div');
+    row.className = 'focus-daily-milestone-row' + (animate && !prefersReduced ? ' is-entering' : '');
+    row.dataset.milestoneId = item.id || dailyMilestoneDraftId();
+    const name = document.createElement('input');
+    name.type = 'text';
+    name.maxLength = 40;
+    name.className = 'focus-daily-milestone-name';
+    name.dataset.role = 'daily-milestone-name';
+    name.placeholder = T('小目标名称');
+    name.setAttribute('aria-label', T('小目标名称'));
+    name.value = item.name || '';
+    const daysWrap = document.createElement('label');
+    daysWrap.className = 'focus-daily-milestone-days-wrap';
+    const days = document.createElement('input');
+    days.type = 'number';
+    days.min = '1';
+    days.max = String(dailyEditTargetDays(dailyEditId) || 3660);
+    days.step = '1';
+    days.className = 'focus-daily-milestone-days';
+    days.dataset.role = 'daily-milestone-days';
+    days.setAttribute('aria-label', T('累计天数'));
+    days.value = Number(item.days) > 0 ? String(item.days) : '';
+    const unit = document.createElement('span');
+    unit.textContent = T('天');
+    daysWrap.append(days, unit);
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'focus-daily-milestone-remove';
+    remove.dataset.action = 'daily-milestone-remove';
+    remove.setAttribute('aria-label', T('删除这个小目标'));
+    remove.textContent = '×';
+    row.append(name, daysWrap, remove);
+    list.appendChild(row);
+    if (row.classList.contains('is-entering')) window.setTimeout(() => row.classList.remove('is-entering'), 260);
+    updateDailyMilestoneAddState();
+    return row;
+  }
+  function readDailyMilestoneDialog() {
+    const targetDays = dailyEditTargetDays(dailyEditId);
+    if (!targetDays) return { error: T('请先设置累计目标') };
+    const rows = Array.from(dailyMilestoneDialog.querySelectorAll('.focus-daily-milestone-row:not(.is-leaving)'));
+    const result = [];
+    const seenDays = new Set();
+    for (let index = 0; index < rows.length; index += 1) {
+      const row = rows[index];
+      const nameInput = row.querySelector('[data-role="daily-milestone-name"]');
+      const daysInput = row.querySelector('[data-role="daily-milestone-days"]');
+      const name = String(nameInput && nameInput.value || '').trim();
+      const rawDays = String(daysInput && daysInput.value || '').trim();
+      const days = /^\d+$/.test(rawDays) ? Number(rawDays) : 0;
+      row.classList.remove('has-error');
+      if (!name) {
+        row.classList.add('has-error');
+        if (nameInput) nameInput.focus();
+        return { error: T('请填写小目标名称') };
+      }
+      if (name.length > 40) {
+        row.classList.add('has-error');
+        if (nameInput) nameInput.focus();
+        return { error: T('小目标名称不能超过 40 个字符') };
+      }
+      if (!days || days > targetDays) {
+        row.classList.add('has-error');
+        if (daysInput) daysInput.focus();
+        return { error: T('小目标天数必须在 1 到累计目标之间') };
+      }
+      if (seenDays.has(days)) {
+        row.classList.add('has-error');
+        if (daysInput) daysInput.focus();
+        return { error: T('同一天只能设置一个小目标') };
+      }
+      seenDays.add(days);
+      result.push({ id: row.dataset.milestoneId || dailyMilestoneDraftId(), name: name, days: days });
+    }
+    result.sort((a, b) => a.days - b.days);
+    return { milestones: result };
+  }
+  function openDailyMilestoneDialog(id, returnElement) {
+    const targetDays = dailyEditTargetDays(id);
+    if (!targetDays) { toast(T('请先设置累计目标')); return; }
+    if (dailyMilestoneDialog) closeDailyMilestoneDialog(false, true);
+    dailyMilestoneDialogDraft = cloneDailyMilestones(dailyEditMilestones);
+    dailyMilestoneReturnEl = returnElement || null;
+    const shell = document.createElement('div');
+    shell.className = 'focus-daily-milestone-shell';
+    shell.dataset.role = 'daily-milestone-dialog';
+    const dialog = document.createElement('section');
+    dialog.className = 'focus-daily-milestone-dialog';
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    dialog.setAttribute('aria-labelledby', 'focus-daily-milestone-title');
+    const head = document.createElement('header');
+    const heading = document.createElement('div');
+    const eyebrow = document.createElement('span');
+    eyebrow.textContent = T('累计目标') + ' · ' + targetDays + T('天');
+    const title = document.createElement('h2');
+    title.id = 'focus-daily-milestone-title';
+    title.textContent = T('高级设置');
+    heading.append(eyebrow, title);
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.dataset.action = 'daily-milestone-cancel';
+    close.setAttribute('aria-label', T('关闭高级设置'));
+    close.textContent = '×';
+    head.append(heading, close);
+    const intro = document.createElement('p');
+    intro.className = 'focus-daily-milestone-intro';
+    intro.textContent = T('把累计目标拆成最多 6 个有名字的小目标。达成状态会根据累计打卡天数自动点亮。');
+    const list = document.createElement('div');
+    list.className = 'focus-daily-milestone-list';
+    list.dataset.role = 'daily-milestone-list';
+    const error = document.createElement('p');
+    error.className = 'focus-daily-milestone-error';
+    error.dataset.role = 'daily-milestone-error';
+    error.setAttribute('aria-live', 'polite');
+    const footer = document.createElement('footer');
+    const add = document.createElement('button');
+    add.type = 'button';
+    add.className = 'focus-daily-milestone-add';
+    add.dataset.action = 'daily-milestone-add';
+    const footerActions = document.createElement('div');
+    const cancel = document.createElement('button');
+    cancel.type = 'button';
+    cancel.className = 'focus-daily-milestone-cancel';
+    cancel.dataset.action = 'daily-milestone-cancel';
+    cancel.textContent = T('取消');
+    const confirm = document.createElement('button');
+    confirm.type = 'button';
+    confirm.className = 'focus-daily-milestone-confirm';
+    confirm.dataset.action = 'daily-milestone-confirm';
+    confirm.textContent = T('确定');
+    footerActions.append(cancel, confirm);
+    footer.append(add, footerActions);
+    dialog.append(head, intro, list, error, footer);
+    shell.appendChild(dialog);
+    root.appendChild(shell);
+    dailyMilestoneDialog = shell;
+    dailyMilestoneDialogDraft.forEach((item) => appendDailyMilestoneDraftRow(item, false));
+    updateDailyMilestoneAddState();
+    requestAnimationFrame(() => shell.classList.add('is-open'));
+    const first = shell.querySelector('input, [data-action="daily-milestone-add"]');
+    if (first) first.focus();
+  }
+  function closeDailyMilestoneDialog(apply, instant) {
+    const shell = dailyMilestoneDialog;
+    if (!shell) return;
+    if (apply) {
+      const result = readDailyMilestoneDialog();
+      if (result.error) { setDailyMilestoneDialogError(result.error); return; }
+      dailyEditMilestones = result.milestones;
+    }
+    const returnEl = dailyMilestoneReturnEl;
+    let finished = false;
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      if (shell.isConnected) shell.remove();
+      if (dailyMilestoneDialog === shell) dailyMilestoneDialog = null;
+      dailyMilestoneDialogDraft = [];
+      dailyMilestoneReturnEl = null;
+      const row = dailyListEl && dailyListEl.querySelector('.focus-daily-row[data-id="' + dailyEditId + '"]');
+      const button = row && row.querySelector('[data-role="daily-edit-advanced"]');
+      if (button) button.textContent = T('高级设置') + (dailyEditMilestones && dailyEditMilestones.length ? ' · ' + dailyEditMilestones.length + '/6' : '');
+      if (!instant && returnEl && returnEl.isConnected) returnEl.focus();
+    };
+    if (instant || prefersReduced) { finish(); return; }
+    shell.classList.remove('is-open');
+    shell.classList.add('is-closing');
+    shell.addEventListener('animationend', finish, { once: true });
+    window.setTimeout(finish, 260);
   }
   function updateDailyFoot() {
     if (!dailyFootEl) return;
@@ -2363,7 +2743,7 @@
     if (!dailyFootEl || prefersReduced) return;
     replayClass(dailyFootEl, 'is-updating');
   }
-  function startDailyClear() {
+  function startDailyClear(settleDelay) {
     clearTimeout(dailyClearTimer);
     dailyClearing = true;
     if (dailyRoot) dailyRoot.classList.add('is-completing');
@@ -2381,7 +2761,7 @@
       const reveal = () => { if (!fired) { fired = true; dailyClearing = false; showDailyCelebrate(true); } };
       if (last && !prefersReduced) last.addEventListener('animationend', reveal, { once: true });
       dailyClearTimer = setTimeout(reveal, items.length * 76 + 460);
-    }, 240);
+    }, Math.max(0, Number(settleDelay) || 240));
   }
   function showDailyCelebrate(animate) {
     if (!dailyCelebrateEl) return;
@@ -2732,10 +3112,16 @@
     endDailyPointerDrag(event, false);
   }
   function onDailyPointerDown(event) {
+    const milestone = event.target.closest('.focus-daily-milestone');
+    if (milestone) {
+      event.stopPropagation();
+      if (event.pointerType === 'mouse') event.preventDefault();
+      return;
+    }
     if (event.button !== 0 || dailyEditId || dailyGroupEditId || dailyConfirmDeleteId
         || dailyGroupConfirmDeleteId || dailyClearing || dailyDrag) return;
     // 这些控件是纯点击，不从它们起拖（勾选 / 编辑器内部 / 折叠箭头 / ⋯菜单）
-    if (event.target.closest('[data-role="daily-check"], [data-role="daily-history"], [data-role="daily-menu"], .focus-daily-edit, [data-role="daily-group-toggle"], [data-role="daily-group-menu"]')) return;
+    if (event.target.closest('[data-role="daily-check"], [data-role="daily-history"], [data-role="daily-menu"], .focus-daily-edit, .focus-daily-milestone, [data-role="daily-group-toggle"], [data-role="daily-group-menu"]')) return;
     const taskRow = event.target.closest('.focus-daily-row');
     const groupRow = taskRow ? null : event.target.closest('.focus-daily-group');
     const el = taskRow || groupRow;
@@ -2776,7 +3162,9 @@
     dailyHintTimers.set(row, window.setTimeout(() => row.classList.remove('is-hint'), 640));
   }
   function openDailyEdit(id) {
+    const task = dailyTasks.find((item) => item.id === id);
     dailyEditId = id;
+    dailyEditMilestones = cloneDailyMilestones(task && task.milestones);
     dailyConfirmDeleteId = '';
     rebuildDailyRows({ flip: true });
     const input = dailyListEl.querySelector('.focus-daily-row[data-id="' + id + '"] .focus-daily-edit-name');
@@ -2784,6 +3172,7 @@
   }
   function closeDailyEdit() {
     if (!dailyEditId) return;
+    if (dailyMilestoneDialog) closeDailyMilestoneDialog(false, true);
     const id = dailyEditId;
     const edit = dailyListEl
       ? dailyListEl.querySelector('.focus-daily-row[data-id="' + id + '"] .focus-daily-edit')
@@ -2791,6 +3180,7 @@
     const finish = () => {
       if (dailyEditId !== id) return;
       dailyEditId = '';
+      dailyEditMilestones = null;
       dailyConfirmDeleteId = '';
       rebuildDailyRows({ flip: true });
     };
@@ -2811,18 +3201,42 @@
     if (!row) { dailyEditId = ''; return; }
     const nameIn = row.querySelector('.focus-daily-edit-name');
     const targetIn = row.querySelector('.focus-daily-edit-min');
+    const goalIn = row.querySelector('.focus-daily-edit-days');
     const name = (nameIn ? nameIn.value : '').trim();
     if (!name) { if (nameIn) nameIn.focus(); toast('名称不能为空'); return; }
     const target = Math.max(0, Math.min(600, parseInt(targetIn ? targetIn.value : '0', 10) || 0));
+    const targetDays = Math.max(0, Math.min(3660, parseInt(goalIn ? goalIn.value : '0', 10) || 0));
+    const milestones = cloneDailyMilestones(dailyEditMilestones);
+    if (milestones.length && !targetDays) {
+      if (goalIn) goalIn.focus();
+      toast(T('请先移除小目标，再清除累计目标'));
+      return;
+    }
+    const over = milestones.find((item) => item.days > targetDays);
+    if (over) {
+      if (goalIn) goalIn.focus();
+      toast('「' + over.name + '」' + T('不能超过累计目标'));
+      return;
+    }
     const groupSel = row.querySelector('[data-role="daily-edit-group"]');
-    const body = { id: id, name: name, targetMinutes: target };
+    const body = { id: id, name: name, targetMinutes: target, targetDays: targetDays, milestones: milestones };
     if (groupSel) body.groupId = groupSel.value || '';
-    dailyEditId = '';
-    dailyConfirmDeleteId = '';
-    rebuildDailyRows({ flip: true });
+    const edit = row.querySelector('.focus-daily-edit');
+    if (edit && edit.classList.contains('is-saving')) return;
+    if (edit) edit.classList.add('is-saving');
     post('/api/daily-update', body)
-      .then((json) => { applyDailyPayload(json); renderDaily(); renderTaskOptions(); })
-      .catch((error) => toast(error.message));
+      .then((json) => {
+        dailyEditId = '';
+        dailyEditMilestones = null;
+        dailyConfirmDeleteId = '';
+        applyDailyPayload(json);
+        renderDaily();
+        renderTaskOptions();
+      })
+      .catch((error) => {
+        if (edit) edit.classList.remove('is-saving');
+        toast(error.message);
+      });
   }
   function requestDeleteDaily(id) {
     // 二次确认：把编辑器就地切到「确认删除？」，不弹原生 confirm
@@ -2834,8 +3248,10 @@
     rebuildDailyRows({ flip: true });
   }
   function performDeleteDaily(id) {
+    if (dailyMilestoneDialog) closeDailyMilestoneDialog(false, true);
     dailyConfirmDeleteId = '';
     dailyEditId = '';
+    dailyEditMilestones = null;
     rebuildDailyRows({ flip: true });   // 先收起确认编辑器，行回到常态，再滑出收拢
     const send = () => post('/api/daily-delete', { id: id })
       .then((json) => { applyDailyPayload(json); renderDaily(); renderTaskOptions(); toast('已删除'); })
@@ -3077,13 +3493,14 @@
   }
   // 勾选只切换该行的完成态（不整列重建），对勾弹入与删除线生长才有过渡；
   // 统计数字等服务端真值回来后就地补，不打断动画。全部完成的清场/庆祝照旧判定。
-  function dailyCelebrationCheck() {
+  function dailyCelebrationCheck(options) {
+    const opts = options || {};
     const allDone = allDailyDone();
     if (!allDone) dailyPeek = false;
     const became = allDone && !dailyWasAllDone;
     dailyWasAllDone = allDone;
     if (allDone && !dailyPeek) {
-      if (became && !prefersReduced) startDailyClear();
+      if (became && !prefersReduced) startDailyClear(opts.waitForMilestone ? 1420 : (opts.waitForGoal ? 860 : 240));
       else showDailyCelebrate(false);
     } else {
       hideDailyCelebrate();
@@ -3093,27 +3510,35 @@
     if (!row) return;
     row.classList.toggle('is-done', done);
     const check = row.querySelector('.focus-daily-check');
-    if (check) check.setAttribute('aria-pressed', done ? 'true' : 'false');
+    if (check) {
+      const task = dailyTasks.find((item) => item.id === row.dataset.id);
+      check.setAttribute('aria-pressed', done ? 'true' : 'false');
+      check.setAttribute('aria-label', (done ? '取消完成 · ' : '标记完成 · ') + (task && task.name || '每日任务'));
+    }
     if (!prefersReduced) {
       replayClass(row, done ? 'is-complete-pop' : 'is-reopen-pop');
       const stat = row.querySelector('.focus-daily-stat');
       replayClass(stat, 'is-updating');
     }
   }
-  function refreshDailyRowStats(task) {
+  function refreshDailyRowStats(task, options) {
     const row = dailyListEl.querySelector('.focus-daily-row[data-id="' + task.id + '"]');
     if (!row) return;
     const stat = row.querySelector('.focus-daily-stat');
     if (stat) stat.textContent = dailyStatText(task);
-    const target = Number(task.targetMinutes) || 0;
-    const fill = row.querySelector('.focus-daily-bar span');
-    const label = row.querySelector('.focus-daily-bar-label');
-    if (target > 0 && fill) {
-      const today = Number(task.todayMinutes) || 0;
-      const pct = Math.max(0, Math.min(1, today / target));
-      fill.style.width = (pct * 100).toFixed(0) + '%';
-      fill.classList.toggle('is-full', pct >= 1);
-      if (label) label.textContent = '今天 ' + today + ' / ' + target + ' 分' + (today >= target ? ' · 达标 ✦' : '');
+    syncDailyGoalProgress(row.querySelector('.focus-daily-goal-shell'), task, options);
+  }
+  function refreshDailyDetailGoal(task, options) {
+    if (!task || dailyDetailTaskId !== task.id) return;
+    const shell = root.querySelector('[data-role="daily-detail"]');
+    if (!shell) return;
+    const text = shell.querySelector('[data-role="daily-detail-goal-text"]');
+    if (text) text.textContent = dailyGoalProgressText(task);
+    syncDailyGoalProgress(shell.querySelector('.focus-daily-goal-shell'), task, options);
+    const toggle = shell.querySelector('[data-action="daily-detail-toggle"]');
+    if (toggle) {
+      toggle.setAttribute('aria-pressed', task.doneToday ? 'true' : 'false');
+      toggle.textContent = task.doneToday ? T('取消今日打卡') : T('今日打卡');
     }
   }
   // 三期：把刚因这次勾选而「整组完成」的最高祖先组自动收起。延迟到对勾/删除线动画走完；
@@ -3146,19 +3571,32 @@
     const task = dailyTasks.find((item) => item.id === id);
     if (!task) return;
     const want = !task.doneToday;
+    const prevTotalDays = Math.max(0, Number(task.totalDays) || 0);
+    const targetDays = dailyGoalState(task).target;
     task.doneToday = want;
     const today = todayStr();
     const prevDates = Array.isArray(task.doneDates) ? task.doneDates.slice() : [];
     const nextDates = prevDates.slice();
     if (want && nextDates.indexOf(today) < 0) nextDates.push(today);
     task.doneDates = want ? nextDates.sort() : nextDates.filter((day) => day !== today);
+    task.totalDays = want ? prevTotalDays + 1 : Math.max(0, prevTotalDays - 1);
+    const reachedNow = want && targetDays > 0 && prevTotalDays < targetDays && task.totalDays >= targetDays;
+    const crossedMilestones = want ? dailyMilestoneList(task)
+      .filter((milestone) => prevTotalDays < milestone.days && task.totalDays >= milestone.days)
+      .map((milestone) => milestone.id) : [];
     const row = dailyListEl.querySelector('.focus-daily-row[data-id="' + id + '"]');
     setRowDone(row, want);
+    const goalMotion = { glow: want && targetDays > 0, reached: reachedNow, milestoneIds: crossedMilestones };
+    refreshDailyRowStats(task, goalMotion);
+    refreshDailyDetailGoal(task, goalMotion);
     refreshDailyGroupProgress(task.groupId);
     updateDailyFoot();
     pulseDailyFoot();
     renderDailyHistory();
-    dailyCelebrationCheck();
+    dailyCelebrationCheck({
+      waitForGoal: want && targetDays > 0,
+      waitForMilestone: want && crossedMilestones.length > 0,
+    });
     maybeAutoCollapseCompletedGroup(id);
     post('/api/daily-toggle', { id: id, done: want })
       .then((json) => {
@@ -3166,6 +3604,7 @@
         const fresh = dailyTasks.find((item) => item.id === id);
         if (fresh) {
           if (!dailyClearing) refreshDailyRowStats(fresh);
+          refreshDailyDetailGoal(fresh);
           refreshDailyGroupProgress(fresh.groupId);
         }
         renderDailyHistory();
@@ -3174,7 +3613,10 @@
       .catch((error) => {
         task.doneToday = !want;
         task.doneDates = prevDates;
+        task.totalDays = prevTotalDays;
         setRowDone(row, !want);
+        refreshDailyRowStats(task);
+        refreshDailyDetailGoal(task);
         refreshDailyGroupProgress(task.groupId);
         updateDailyFoot();
         pulseDailyFoot();
@@ -3392,7 +3834,29 @@
     savePreferences();
     if (noisePlaying) rampNoise(noiseTarget());
   });
+  root.addEventListener('pointerdown', (event) => {
+    if (!event.target.closest('.focus-daily-milestone')) return;
+    event.stopPropagation();
+    if (event.pointerType === 'mouse') event.preventDefault();
+  });
   root.addEventListener('click', (event) => {
+    const marker = event.target.closest('.focus-daily-milestone');
+    if (marker) {
+      event.preventDefault();
+      event.stopPropagation();
+      const coarse = window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
+      if (coarse) {
+        root.querySelectorAll('.focus-daily-milestone.is-tip-pinned').forEach((item) => {
+          if (item !== marker) item.classList.remove('is-tip-pinned');
+        });
+        marker.classList.toggle('is-tip-pinned');
+      }
+      return;
+    }
+    if (dailyMilestoneDialog && event.target === dailyMilestoneDialog) {
+      closeDailyMilestoneDialog(false);
+      return;
+    }
     const detailShell = event.target.closest('[data-role="daily-detail"]');
     if (detailShell && event.target === detailShell) {
       closeDailyDetail();
@@ -3400,6 +3864,30 @@
     }
     const action = event.target.closest('[data-action]');
     if (!action) return;
+    if (action.dataset.action === 'daily-milestone-add') {
+      if (!action.disabled) {
+        const row = appendDailyMilestoneDraftRow({ id: dailyMilestoneDraftId(), name: '', days: 0 }, true);
+        const input = row && row.querySelector('[data-role="daily-milestone-name"]');
+        if (input) input.focus();
+        setDailyMilestoneDialogError('');
+      }
+      return;
+    }
+    if (action.dataset.action === 'daily-milestone-remove') {
+      const row = action.closest('.focus-daily-milestone-row');
+      if (!row) return;
+      const finish = () => { if (row.isConnected) row.remove(); updateDailyMilestoneAddState(); };
+      if (prefersReduced) finish();
+      else {
+        row.classList.add('is-leaving');
+        row.addEventListener('animationend', finish, { once: true });
+        window.setTimeout(finish, 220);
+      }
+      setDailyMilestoneDialogError('');
+      return;
+    }
+    if (action.dataset.action === 'daily-milestone-cancel') { closeDailyMilestoneDialog(false); return; }
+    if (action.dataset.action === 'daily-milestone-confirm') { closeDailyMilestoneDialog(true); return; }
     if (action.dataset.action === 'focus-wrapup-next') finishWrapup('next').catch(() => {});
     if (action.dataset.action === 'focus-wrapup-stop') finishWrapup('stop').catch(() => {});
     if (action.dataset.action === 'focus-wrapup-done') finishWrapup('done').catch(() => {});
@@ -3461,12 +3949,29 @@
         event.stopPropagation();
         return;
       }
+      const milestone = event.target.closest('.focus-daily-milestone');
+      if (milestone) {
+        event.preventDefault();
+        event.stopPropagation();
+        const coarse = window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
+        if (coarse) {
+          dailyListEl.querySelectorAll('.focus-daily-milestone.is-tip-pinned').forEach((item) => {
+            if (item !== milestone) item.classList.remove('is-tip-pinned');
+          });
+          milestone.classList.toggle('is-tip-pinned');
+        }
+        return;
+      }
       // 任务行优先：任务现在嵌在 .focus-daily-group 里，必须先判任务，否则点勾选会被外层分组分支吃掉
       const row = event.target.closest('.focus-daily-row');
       if (row) {
         const id = row.dataset.id;
         if (event.target.closest('[data-role="daily-check"]')) { toggleDailyTask(id); return; }
         if (event.target.closest('[data-role="daily-history"]')) { openDailyHistory(id); return; }
+        if (event.target.closest('[data-role="daily-edit-advanced"]')) {
+          openDailyMilestoneDialog(id, event.target.closest('[data-role="daily-edit-advanced"]'));
+          return;
+        }
         if (event.target.closest('[data-role="daily-edit-save"]')) { commitDailyEdit(id); return; }
         if (event.target.closest('[data-role="daily-edit-delete"]')) { requestDeleteDaily(id); return; }
         if (event.target.closest('[data-role="daily-delete-cancel"]')) { cancelDeleteDaily(); return; }
@@ -3509,7 +4014,7 @@
         else if (event.key === 'Escape') { event.preventDefault(); event.stopPropagation(); closeDailyGroupEdit(); }
         return;
       }
-      if (!event.target.matches('.focus-daily-edit-name, .focus-daily-edit-min')) return;
+      if (!event.target.matches('.focus-daily-edit-name, .focus-daily-edit-min, .focus-daily-edit-days')) return;
       const row = event.target.closest('.focus-daily-row');
       if (!row) return;
       if (event.key === 'Enter') { event.preventDefault(); commitDailyEdit(row.dataset.id); }
@@ -3527,6 +4032,9 @@
   if (dailyComposeGroupBtn) dailyComposeGroupBtn.addEventListener('click', () => setDailyCompose('group', dailyAddTargetGroup));
   if (dailyComposeTargetBtn) dailyComposeTargetBtn.addEventListener('click', () => setDailyCompose(dailyComposeMode, ''));
   document.addEventListener('click', (event) => {
+    if (!event.target.closest('.focus-daily-milestone')) {
+      root.querySelectorAll('.focus-daily-milestone.is-tip-pinned').forEach((item) => item.classList.remove('is-tip-pinned'));
+    }
     if (settingsPop && !settingsPop.hidden
       && !settingsPop.contains(event.target) && !(gearBtn && gearBtn.contains(event.target))) {
       toggleSettings(false);
@@ -3537,6 +4045,38 @@
     }
   });
   document.addEventListener('keydown', (event) => {
+    if (dailyMilestoneDialog) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        closeDailyMilestoneDialog(false);
+        return;
+      }
+      if (event.key === 'Tab') {
+        const focusables = Array.from(dailyMilestoneDialog.querySelectorAll(dailyFocusableSelector))
+          .filter((item) => !item.disabled && item.getAttribute('aria-hidden') !== 'true');
+        if (focusables.length) {
+          const first = focusables[0];
+          const last = focusables[focusables.length - 1];
+          if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      }
+      return;
+    }
+    if (event.key === 'Escape') {
+      const pinned = root.querySelector('.focus-daily-milestone.is-tip-pinned');
+      if (pinned) {
+        event.preventDefault();
+        pinned.classList.remove('is-tip-pinned');
+        return;
+      }
+    }
     if (!focusPageActive()) return;
     const target = event.target;
     const typing = isTypingTarget(target);

--- a/assets/i18n.js
+++ b/assets/i18n.js
@@ -750,7 +750,30 @@
     '最近打卡': 'Recent check-ins',
     '未分组': 'Ungrouped',
     '今日目标': 'Daily goal',
+    '累计目标': 'Cumulative goal',
+    '累计打卡目标': 'Cumulative check-in goal',
+    '累计打卡目标天数': 'Cumulative check-in goal in days',
+    '高级设置': 'Advanced settings',
+    '设置累计小目标': 'Set cumulative milestones',
+    '请先设置累计目标': 'Set a cumulative goal first',
+    '请先移除小目标，再清除累计目标': 'Remove the milestones before clearing the cumulative goal',
+    '不能超过累计目标': ' cannot exceed the cumulative goal',
+    '小目标名称': 'Milestone name',
+    '累计天数': 'Cumulative days',
+    '删除这个小目标': 'Delete this milestone',
+    '添加小目标': 'Add milestone',
+    '已达到 6 个上限': 'Limit of 6 reached',
+    '关闭高级设置': 'Close advanced settings',
+    '确定': 'Done',
+    '已达成': 'Reached',
+    '未达成': 'Upcoming',
+    '请填写小目标名称': 'Enter a milestone name',
+    '小目标名称不能超过 40 个字符': 'Milestone names can contain at most 40 characters',
+    '小目标天数必须在 1 到累计目标之间': 'Milestone days must be between 1 and the cumulative goal',
+    '同一天只能设置一个小目标': 'Only one milestone can be set on the same day',
+    '把累计目标拆成最多 6 个有名字的小目标。达成状态会根据累计打卡天数自动点亮。': 'Split the cumulative goal into up to 6 named milestones. Each milestone lights up automatically when its day is reached.',
     '分钟 · 可选': 'Minutes · optional',
+    '天 · 可选': 'Days · optional',
     '每日任务名称': 'Daily task name',
     '关闭每日任务详情': 'Close daily task details',
     '今天还没开始': 'Not started today',
@@ -1024,6 +1047,10 @@
     if (match) return `${match[1]} min total`;
     match = source.match(/^今天\s*(\d+)\s*分$/);
     if (match) return `${match[1]} min today`;
+    match = source.match(/^累计\s*(\d+)\s*\/\s*(\d+)\s*天\s*·\s*已达成$/);
+    if (match) return `${match[1]} / ${match[2]} days total · goal met`;
+    match = source.match(/^累计\s*(\d+)\s*\/\s*(\d+)\s*天$/);
+    if (match) return `${match[1]} / ${match[2]} days total`;
     match = source.match(/^(\d+)\s*件全部完成\s*·\s*专注\s*(\d+)\s*分钟\s*·\s*明天见$/);
     if (match) return `${match[1]} all complete · ${match[2]} min focused · See you tomorrow`;
     match = source.match(/^(\d+)\s*件全部完成\s*·\s*明天见$/);

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -8777,11 +8777,11 @@ body.start-page[data-start-theme="dark"] .focus-overlay-card {
 
 .focus-daily {
   position: absolute;
-  top: clamp(84px, 13vh, 122px);
+  top: clamp(42px, 6vh, 58px);
   right: clamp(14px, 3vw, 52px);
-  bottom: clamp(20px, 6vh, 56px);
+  bottom: clamp(8px, 1.5vh, 16px);
   z-index: 15;
-  width: clamp(298px, 30vw, 366px);
+  width: clamp(360px, 32vw, 440px);
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -8831,7 +8831,7 @@ body.start-page[data-start-theme="dark"] .focus-overlay-card {
   display: flex;
   align-items: flex-start;
   gap: 11px;
-  padding: 10px 8px;
+  padding: 15px 8px;
   border-radius: 13px;
   transition: background 200ms var(--easing-soft), opacity 200ms var(--easing-soft),
               box-shadow 220ms var(--easing-soft), filter 220ms var(--easing-soft);
@@ -9022,10 +9022,161 @@ body.focus-daily-dragging .focus-daily-row { will-change: transform; }
 .focus-daily-stat { margin-top: 3px; color: var(--text-tertiary); font-size: 11.5px; line-height: 1.5; }
 .focus-daily-stat.is-updating { animation: focus-daily-stat-pop 260ms var(--easing-soft) both; }
 .focus-daily-row.is-done .focus-daily-stat { opacity: 0.72; }
-.focus-daily-bar-label { margin-top: 5px; color: var(--text-secondary); font-size: 11px; }
-.focus-daily-bar { margin-top: 4px; height: 4px; border-radius: 999px; background: color-mix(in srgb, var(--text) 9%, transparent); overflow: hidden; }
-.focus-daily-bar span { display: block; height: 100%; border-radius: 999px; background: color-mix(in srgb, var(--text) 42%, transparent); transition: width 520ms var(--easing-page), background 360ms var(--easing-soft); }
-.focus-daily-bar span.is-full { background: #5f9e6c; }
+.focus-daily-goal-shell {
+  position: relative;
+  height: 22px;
+  margin-top: 3px;
+  isolation: isolate;
+}
+.focus-daily-goal {
+  position: relative;
+  top: 8px;
+  height: 6px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text) 9%, transparent);
+  isolation: isolate;
+}
+.focus-daily-goal .focus-daily-goal-fill {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #729f79, #86ae84);
+  transition: width 620ms cubic-bezier(0.22, 1, 0.36, 1), background 320ms var(--easing-soft);
+}
+.focus-daily-goal.is-full .focus-daily-goal-fill { background: linear-gradient(90deg, #5f9e6c, #d0ad58); }
+.focus-daily-goal::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+  background: linear-gradient(105deg, transparent 20%, rgba(255, 249, 220, 0.84) 48%, transparent 72%);
+  opacity: 0;
+  transform: translateX(-145%);
+  pointer-events: none;
+}
+.focus-daily-goal.is-advancing,
+.focus-daily-detail-progress.is-cumulative.is-advancing { animation: focus-daily-goal-glow 780ms var(--easing-soft) both; }
+.focus-daily-goal.is-goal-reached,
+.focus-daily-detail-progress.is-cumulative.is-goal-reached { animation: focus-daily-goal-reached 920ms var(--easing-soft) both; }
+.focus-daily-goal.is-advancing::after,
+.focus-daily-goal.is-goal-reached::after { animation: focus-daily-goal-sheen 720ms 70ms var(--easing-soft) both; }
+@keyframes focus-daily-goal-glow {
+  0%, 100% { box-shadow: 0 0 0 rgba(104, 158, 113, 0); }
+  38% { box-shadow: 0 0 11px rgba(104, 158, 113, 0.48), 0 0 3px rgba(215, 173, 77, 0.22); }
+}
+@keyframes focus-daily-goal-reached {
+  0%, 100% { box-shadow: 0 0 0 rgba(104, 158, 113, 0); }
+  34% { box-shadow: 0 0 15px rgba(104, 158, 113, 0.56), 0 0 7px rgba(215, 173, 77, 0.42); }
+}
+@keyframes focus-daily-goal-sheen {
+  0% { opacity: 0; transform: translateX(-145%); }
+  28% { opacity: 1; }
+  100% { opacity: 0; transform: translateX(145%); }
+}
+.focus-daily-milestones {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+  overflow: visible;
+}
+.focus-daily-milestone {
+  position: absolute;
+  left: clamp(6px, var(--milestone-position), calc(100% - 6px));
+  top: calc(11px + var(--milestone-lane, 0) * 6px);
+  width: 15px;
+  height: 15px;
+  transform: translate(-50%, -50%);
+  pointer-events: auto;
+  cursor: default;
+  outline: none;
+  z-index: calc(5 + var(--milestone-lane, 0));
+  transition: left 420ms var(--easing-page), top 320ms var(--easing-soft), opacity 180ms var(--easing-soft), transform 180ms var(--easing-soft);
+}
+.focus-daily-milestone-stamp {
+  position: absolute;
+  inset: 2px;
+  border: 1.5px solid color-mix(in srgb, var(--text) 34%, var(--surface));
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--surface) 94%, var(--text) 6%);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--surface) 82%, transparent);
+  transition: border-color 220ms var(--easing-soft), background 220ms var(--easing-soft), box-shadow 220ms var(--easing-soft), transform 180ms var(--easing-soft);
+}
+.focus-daily-milestone.is-reached .focus-daily-milestone-stamp {
+  border-color: #5f9e6c;
+  background: #6da779;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--surface) 86%, transparent), 0 1px 5px rgba(76, 130, 87, 0.32);
+}
+.focus-daily-milestone:focus-visible .focus-daily-milestone-stamp {
+  box-shadow: 0 0 0 2px var(--surface), 0 0 0 4px color-mix(in srgb, #5f9e6c 58%, transparent);
+}
+.focus-daily-milestone-tip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 7px);
+  width: max-content;
+  max-width: min(230px, calc(100vw - 34px));
+  padding: 6px 9px;
+  border: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 97%, #fff 3%);
+  color: var(--text);
+  box-shadow: 0 8px 22px rgba(22, 24, 23, 0.16);
+  font-size: 11px;
+  font-weight: 560;
+  line-height: 1.35;
+  white-space: normal;
+  opacity: 0;
+  visibility: hidden;
+  transform: translate(-50%, 4px) scale(0.97);
+  transform-origin: 50% 100%;
+  transition: opacity 150ms var(--easing-soft) 60ms, transform 170ms var(--easing-soft) 60ms, visibility 0s linear 230ms;
+  pointer-events: none;
+  z-index: 30;
+}
+.focus-daily-milestone.is-edge-start .focus-daily-milestone-tip {
+  left: -1px;
+  transform: translate(0, 4px) scale(0.97);
+  transform-origin: 0 100%;
+}
+.focus-daily-milestone.is-edge-end .focus-daily-milestone-tip {
+  right: -1px;
+  left: auto;
+  transform: translate(0, 4px) scale(0.97);
+  transform-origin: 100% 100%;
+}
+.focus-daily-milestone:hover .focus-daily-milestone-tip,
+.focus-daily-milestone:focus-visible .focus-daily-milestone-tip,
+.focus-daily-milestone.is-tip-pinned .focus-daily-milestone-tip {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0) scale(1);
+  transition-delay: 140ms, 140ms, 0s;
+}
+.focus-daily-milestone.is-edge-start:hover .focus-daily-milestone-tip,
+.focus-daily-milestone.is-edge-start:focus-visible .focus-daily-milestone-tip,
+.focus-daily-milestone.is-edge-start.is-tip-pinned .focus-daily-milestone-tip,
+.focus-daily-milestone.is-edge-end:hover .focus-daily-milestone-tip,
+.focus-daily-milestone.is-edge-end:focus-visible .focus-daily-milestone-tip,
+.focus-daily-milestone.is-edge-end.is-tip-pinned .focus-daily-milestone-tip { transform: translate(0, 0) scale(1); }
+.focus-daily-milestone.is-entering { animation: focus-daily-milestone-in 240ms var(--easing-page) both; }
+.focus-daily-milestone.is-leaving { pointer-events: none; animation: focus-daily-milestone-out 190ms var(--easing-soft) both; }
+.focus-daily-milestone.is-just-reached .focus-daily-milestone-stamp { animation: focus-daily-milestone-reached 880ms 500ms var(--easing-soft) both; }
+@keyframes focus-daily-milestone-in {
+  from { opacity: 0; transform: translate(-50%, -50%) scale(0.45); }
+  to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+@keyframes focus-daily-milestone-out {
+  to { opacity: 0; transform: translate(-50%, -50%) scale(0.42); }
+}
+@keyframes focus-daily-milestone-reached {
+  0%, 100% { transform: scale(1); }
+  34% { transform: scale(1.55); box-shadow: 0 0 0 2px var(--surface), 0 0 0 8px rgba(95, 158, 108, 0.18), 0 0 16px rgba(95, 158, 108, 0.52); }
+  62% { transform: scale(0.92); }
+}
 
 /* —— 分组：就地折叠手风琴。任务/分组同列，靠 --daily-depth 缩进表达层级 —— */
 .focus-daily-row { padding-left: calc(8px + var(--daily-depth, 0) * 16px); }
@@ -9353,9 +9504,26 @@ body.focus-daily-dragging .focus-daily-group-head {
   font-size: 13.5px;
 }
 .focus-daily-edit input:focus-visible { outline: none; border-color: color-mix(in srgb, var(--accent) 38%, var(--border)); }
-.focus-daily-edit-target { display: flex; align-items: center; gap: 9px; font-size: 12px; color: var(--text-secondary); }
-.focus-daily-edit-target span { flex: none; }
-.focus-daily-edit-target input { width: 122px; }
+.focus-daily-edit-target { display: flex; align-items: center; justify-content: space-between; gap: 8px; font-size: 12px; color: var(--text-secondary); }
+.focus-daily-edit-target-field { display: flex; min-width: 0; align-items: center; gap: 9px; }
+.focus-daily-edit-target-field span { flex: none; }
+.focus-daily-edit-target input { width: 112px; }
+.focus-daily-edit-advanced {
+  flex: none;
+  padding: 6px 9px;
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: color 170ms var(--easing-soft), background 170ms var(--easing-soft), border-color 170ms var(--easing-soft), transform 120ms var(--easing-soft), opacity 170ms var(--easing-soft);
+}
+.focus-daily-edit-advanced:not(:disabled):hover { color: var(--text); border-color: color-mix(in srgb, var(--text) 28%, var(--border)); background: color-mix(in srgb, var(--text) 7%, var(--surface)); }
+.focus-daily-edit-advanced:not(:disabled):active { transform: scale(0.97); }
+.focus-daily-edit-advanced:disabled { opacity: 0.42; cursor: not-allowed; }
+.focus-daily-edit.is-saving { pointer-events: none; opacity: 0.68; }
 .focus-daily-edit-actions { display: flex; justify-content: space-between; gap: 10px; }
 .focus-daily-edit-del,
 .focus-daily-edit-save {
@@ -9374,6 +9542,131 @@ body.focus-daily-dragging .focus-daily-group-head {
 .focus-daily-edit-save:hover { background: color-mix(in srgb, var(--text) 8%, transparent); }
 .focus-daily-edit-del:active,
 .focus-daily-edit-save:active { transform: scale(0.97); }
+
+.focus-daily-milestone-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 240;
+  display: grid;
+  place-items: center;
+  padding: 22px;
+  background: rgba(24, 25, 24, 0);
+  opacity: 0;
+  transition: opacity 190ms var(--easing-soft), background 190ms var(--easing-soft);
+}
+.focus-daily-milestone-shell.is-open { opacity: 1; background: rgba(24, 25, 24, 0.28); }
+.focus-daily-milestone-shell.is-closing { animation: focus-daily-milestone-shell-out 210ms var(--easing-soft) both; }
+.focus-daily-milestone-dialog {
+  width: min(560px, calc(100vw - 34px));
+  max-height: min(720px, calc(100vh - 40px));
+  overflow: auto;
+  padding: 21px;
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--surface) 98%, #fff 2%);
+  color: var(--text);
+  box-shadow: 0 28px 72px rgba(24, 26, 25, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  opacity: 0;
+  transform: translateY(10px) scale(0.975);
+  transition: opacity 220ms var(--easing-soft), transform 260ms var(--easing-page);
+}
+.focus-daily-milestone-shell.is-open .focus-daily-milestone-dialog { opacity: 1; transform: translateY(0) scale(1); }
+.focus-daily-milestone-dialog > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.focus-daily-milestone-dialog > header span { display: block; margin-bottom: 3px; color: var(--text-tertiary); font-size: 10.5px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; }
+.focus-daily-milestone-dialog h2 { margin: 0; font-size: 21px; line-height: 1.25; }
+.focus-daily-milestone-dialog > header button {
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-tertiary);
+  font: inherit;
+  font-size: 20px;
+  cursor: pointer;
+  transition: color 160ms var(--easing-soft), background 160ms var(--easing-soft), transform 120ms var(--easing-soft);
+}
+.focus-daily-milestone-dialog > header button:hover { color: var(--text); background: color-mix(in srgb, var(--text) 7%, transparent); }
+.focus-daily-milestone-dialog > header button:active { transform: scale(0.94); }
+.focus-daily-milestone-intro { margin: 13px 0 16px; color: var(--text-secondary); font-size: 12.5px; line-height: 1.6; }
+.focus-daily-milestone-list { display: grid; gap: 8px; }
+.focus-daily-milestone-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 116px 32px;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 5px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--surface) 76%, transparent);
+}
+.focus-daily-milestone-row.is-entering { animation: focus-daily-milestone-row-in 240ms var(--easing-page) both; }
+.focus-daily-milestone-row.is-leaving { pointer-events: none; animation: focus-daily-milestone-row-out 190ms var(--easing-soft) both; }
+.focus-daily-milestone-row.has-error { border-color: color-mix(in srgb, #b4533f 58%, var(--border)); background: color-mix(in srgb, #b4533f 5%, var(--surface)); }
+.focus-daily-milestone-row input {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 6px 9px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+}
+.focus-daily-milestone-row input:focus-visible { outline: none; border-color: color-mix(in srgb, #5f9e6c 54%, var(--border)); }
+.focus-daily-milestone-days-wrap { display: flex; align-items: center; gap: 4px; color: var(--text-tertiary); font-size: 11.5px; }
+.focus-daily-milestone-days-wrap input { min-width: 0; }
+.focus-daily-milestone-remove {
+  width: 30px;
+  height: 30px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-tertiary);
+  font: inherit;
+  font-size: 18px;
+  cursor: pointer;
+  transition: color 160ms var(--easing-soft), background 160ms var(--easing-soft), transform 120ms var(--easing-soft);
+}
+.focus-daily-milestone-remove:hover { color: #b4533f; background: color-mix(in srgb, #b4533f 8%, transparent); }
+.focus-daily-milestone-remove:active { transform: scale(0.92); }
+.focus-daily-milestone-error { min-height: 18px; margin: 8px 2px 0; color: #a44b3a; font-size: 11.5px; line-height: 1.45; }
+.focus-daily-milestone-dialog > footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 5px; }
+.focus-daily-milestone-dialog > footer > div { display: flex; gap: 8px; }
+.focus-daily-milestone-add,
+.focus-daily-milestone-cancel,
+.focus-daily-milestone-confirm {
+  min-height: 36px;
+  padding: 7px 13px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--surface) 82%, transparent);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 170ms var(--easing-soft), background 170ms var(--easing-soft), border-color 170ms var(--easing-soft), transform 120ms var(--easing-soft), opacity 170ms var(--easing-soft);
+}
+.focus-daily-milestone-add:disabled { opacity: 0.42; cursor: not-allowed; }
+.focus-daily-milestone-confirm { color: var(--text); font-weight: 650; border-color: color-mix(in srgb, var(--text) 42%, var(--border)); }
+.focus-daily-milestone-add:not(:disabled):hover,
+.focus-daily-milestone-cancel:hover,
+.focus-daily-milestone-confirm:hover { color: var(--text); background: color-mix(in srgb, var(--text) 7%, var(--surface)); }
+.focus-daily-milestone-add:not(:disabled):active,
+.focus-daily-milestone-cancel:active,
+.focus-daily-milestone-confirm:active { transform: scale(0.97); }
+@keyframes focus-daily-milestone-shell-out { to { opacity: 0; background: rgba(24, 25, 24, 0); } }
+@keyframes focus-daily-milestone-row-in {
+  from { min-height: 0; max-height: 0; padding-top: 0; padding-bottom: 0; opacity: 0; transform: translateY(-5px) scale(0.985); }
+  to { max-height: 56px; opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes focus-daily-milestone-row-out {
+  from { max-height: 56px; opacity: 1; }
+  to { min-height: 0; max-height: 0; padding-top: 0; padding-bottom: 0; border-width: 0; opacity: 0; transform: translateY(-4px) scale(0.98); }
+}
 
 /* 删除二次确认：编辑器就地变「确认删除？」，简洁优雅，不弹原生 confirm */
 .focus-daily-edit.is-confirming {
@@ -9947,11 +10240,14 @@ body.focus-daily-dragging .focus-daily-group-head {
   line-height: 1.55;
 }
 .focus-daily-detail-progress {
+  position: relative;
   height: 8px;
   overflow: hidden;
   border-radius: 999px;
   background: color-mix(in srgb, var(--text) 10%, transparent);
 }
+.focus-daily-detail-progress.is-cumulative { top: 7px; }
+.focus-daily-detail-block .focus-daily-goal-shell { height: 23px; margin-top: 0; }
 .focus-daily-detail-progress span {
   display: block;
   height: 100%;
@@ -9960,6 +10256,9 @@ body.focus-daily-dragging .focus-daily-group-head {
   transition: width 240ms var(--easing-soft);
 }
 .focus-daily-detail-progress span.is-full {
+  background: linear-gradient(90deg, #5f9e6c, #d7ad4d);
+}
+.focus-daily-detail-progress.is-cumulative.is-full .focus-daily-goal-fill {
   background: linear-gradient(90deg, #5f9e6c, #d7ad4d);
 }
 .focus-daily-detail-recent {
@@ -10288,6 +10587,42 @@ body.start-page[data-start-theme="dark"] .focus-daily-edit,
 body.start-page[data-start-theme="dark"] .focus-daily-edit input,
 body.start-page[data-start-theme="dark"] .focus-daily-add input,
 body.start-page[data-start-theme="dark"] .focus-daily-add-btn { background: rgba(15, 17, 18, 0.6); }
+body.start-page[data-start-theme="dark"] .focus-daily-goal {
+  background: rgba(255, 255, 255, 0.11);
+}
+body.start-page[data-start-theme="dark"] .focus-daily-goal .focus-daily-goal-fill {
+  background: linear-gradient(90deg, #75aa7f, #9bc18f);
+}
+body.start-page[data-start-theme="dark"] .focus-daily-goal.is-full .focus-daily-goal-fill {
+  background: linear-gradient(90deg, #72b07f, #d7b85f);
+}
+body.start-page[data-start-theme="dark"] .focus-daily-milestone-stamp {
+  border-color: rgba(242, 241, 237, 0.46);
+  background: #202322;
+  box-shadow: 0 0 0 2px rgba(20, 22, 21, 0.92);
+}
+body.start-page[data-start-theme="dark"] .focus-daily-milestone.is-reached .focus-daily-milestone-stamp {
+  border-color: #81bd8c;
+  background: #6cab78;
+  box-shadow: 0 0 0 2px rgba(20, 22, 21, 0.94), 0 0 8px rgba(111, 181, 124, 0.30);
+}
+body.start-page[data-start-theme="dark"] .focus-daily-milestone-tip {
+  border-color: rgba(255, 255, 255, 0.14);
+  background: #202322;
+  color: #f2f1ed;
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.42);
+}
+body.start-page[data-start-theme="dark"] .focus-daily-milestone-dialog {
+  border-color: rgba(255, 255, 255, 0.14);
+  background: #1d201f;
+  box-shadow: 0 30px 76px rgba(0, 0, 0, 0.58), inset 0 1px 0 rgba(255, 255, 255, 0.07);
+}
+body.start-page[data-start-theme="dark"] .focus-daily-milestone-row,
+body.start-page[data-start-theme="dark"] .focus-daily-milestone-row input,
+body.start-page[data-start-theme="dark"] .focus-daily-milestone-add,
+body.start-page[data-start-theme="dark"] .focus-daily-milestone-cancel,
+body.start-page[data-start-theme="dark"] .focus-daily-milestone-confirm,
+body.start-page[data-start-theme="dark"] .focus-daily-edit-advanced { background: rgba(255, 255, 255, 0.055); }
 
 body.start-page[data-start-theme="dark"] .focus-daily-detail-shell {
   background: rgba(5, 7, 8, 0.52);
@@ -10365,6 +10700,11 @@ body.start-page[data-start-theme="dark"] .focus-daily-detail-recent span.today {
 
 @media (max-width: 720px) {
   .focus-daily { top: 70px; right: 10px; bottom: 14px; left: 10px; width: auto; }
+  .focus-daily-milestone-shell { padding: 12px; }
+  .focus-daily-milestone-dialog { width: min(100%, 560px); max-height: calc(100vh - 24px); padding: 17px; border-radius: 17px; }
+  .focus-daily-milestone-row { grid-template-columns: minmax(0, 1fr) 100px 30px; gap: 5px; }
+  .focus-daily-milestone-dialog > footer { align-items: stretch; flex-direction: column; }
+  .focus-daily-milestone-dialog > footer > div { justify-content: flex-end; }
 }
 @media (prefers-reduced-motion: reduce) {
   .focus-daily,
@@ -10380,7 +10720,22 @@ body.start-page[data-start-theme="dark"] .focus-daily-detail-recent span.today {
   .focus-daily.is-peeking .focus-daily-foot,
   .focus-daily.is-completing .focus-daily-add,
   .focus-daily.is-completing .focus-daily-foot,
-  .focus-daily-bar span,
+  .focus-daily-goal,
+  .focus-daily-goal-shell,
+  .focus-daily-goal::after,
+  .focus-daily-goal .focus-daily-goal-fill,
+  .focus-daily-milestone,
+  .focus-daily-milestone-stamp,
+  .focus-daily-milestone-tip,
+  .focus-daily-milestone.is-entering,
+  .focus-daily-milestone.is-leaving,
+  .focus-daily-milestone.is-just-reached .focus-daily-milestone-stamp,
+  .focus-daily-milestone-shell,
+  .focus-daily-milestone-shell.is-closing,
+  .focus-daily-milestone-dialog,
+  .focus-daily-milestone-row.is-entering,
+  .focus-daily-milestone-row.is-leaving,
+  .focus-daily-detail-progress span,
   .focus-daily-name,
   .focus-daily-name::after,
   .focus-daily-check::after,

--- a/tests/daily-goal-contract.js
+++ b/tests/daily-goal-contract.js
@@ -1,0 +1,93 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const focus = fs.readFileSync(path.join(root, 'assets', 'focus.js'), 'utf8');
+const styles = fs.readFileSync(path.join(root, 'assets', 'styles.css'), 'utf8');
+const i18n = fs.readFileSync(path.join(root, 'assets', 'i18n.js'), 'utf8');
+const backend = fs.readFileSync(path.join(root, 'app.py'), 'utf8');
+
+[
+  'DAILY_GOAL_DAYS_MAX = 3660',
+  'DAILY_MILESTONES_MAX = 6',
+  'DAILY_MILESTONE_NAME_MAX = 40',
+  'def _sanitize_daily_milestones(value: object, target_days: int)',
+  'def _validate_daily_milestones(value: object, target_days: int)',
+  '"milestones": _sanitize_daily_milestones(item.get("milestones"), target_days)',
+  '"milestones": [dict(item) for item in task.get("milestones", [])]',
+  'if "targetDays" in body:',
+  'next_milestones = _validate_daily_milestones(milestone_source, next_target_days)',
+].forEach((needle) => assert(backend.includes(needle), 'missing backend daily-goal contract: ' + needle));
+
+[
+  'function dailyGoalState(task)',
+  'function dailyMilestoneList(task)',
+  'function dailyMilestoneLanes(milestones, target)',
+  'function syncDailyMilestones(shell, task, options)',
+  "shell.className = 'focus-daily-goal-shell'",
+  "bar.dataset.role = 'daily-goal-track'",
+  "bar.setAttribute('role', 'progressbar')",
+  "bar.setAttribute('aria-valuetext', text)",
+  "marker.setAttribute('role', 'img')",
+  "tip.setAttribute('role', 'tooltip')",
+  "if (dailyGoalState(task).target > 0) main.appendChild(buildDailyGoalProgress(task))",
+  "goalIn.max = '3660'",
+  "advanced.dataset.role = 'daily-edit-advanced'",
+  'function openDailyMilestoneDialog(id, returnElement)',
+  "dialog.setAttribute('aria-modal', 'true')",
+  'dailyEditMilestones = result.milestones',
+  'milestones: milestones',
+  'task.totalDays = want ? prevTotalDays + 1 : Math.max(0, prevTotalDays - 1)',
+  'milestoneIds: crossedMilestones',
+  'refreshDailyRowStats(task, goalMotion)',
+  'task.totalDays = prevTotalDays',
+  'waitForGoal: want && targetDays > 0,',
+  'opts.waitForMilestone ? 1420',
+  'waitForMilestone: want && crossedMilestones.length > 0',
+  'function refreshDailyDetailGoal(task, options)',
+  "dailyDetailBlock(T('累计目标'))",
+  "dailyDetailBlock('今日进度')",
+  "event.target.closest('.focus-daily-milestone')",
+  "window.matchMedia('(pointer: coarse)').matches",
+].forEach((needle) => assert(focus.includes(needle), 'missing frontend daily-goal contract: ' + needle));
+
+assert(!focus.includes("bar.className = 'focus-daily-bar'"),
+  'daily cards must no longer render the old per-day minute bar');
+assert(focus.includes('task.targetMinutes'),
+  'daily minute targets must remain available outside the compact card bar');
+assert(!focus.includes('bar.title = text'),
+  'milestone progress must not depend on the delayed global title tooltip');
+
+[
+  '.focus-daily-goal {',
+  '.focus-daily-goal-shell {',
+  '.focus-daily-milestones {',
+  '.focus-daily-milestone-stamp {',
+  '.focus-daily-milestone-tip {',
+  '.focus-daily-milestone-shell {',
+  '.focus-daily-milestone-row.is-leaving',
+  'height: 6px;',
+  'transition: width 620ms',
+  '@keyframes focus-daily-goal-glow',
+  '@keyframes focus-daily-goal-reached',
+  '@keyframes focus-daily-goal-sheen',
+  '@keyframes focus-daily-milestone-reached',
+  '@keyframes focus-daily-milestone-row-out',
+  'body.start-page[data-start-theme="dark"] .focus-daily-goal',
+  'body.start-page[data-start-theme="dark"] .focus-daily-milestone-dialog',
+  '@media (prefers-reduced-motion: reduce)',
+  '.focus-daily-goal::after,',
+].forEach((needle) => assert(styles.includes(needle), 'missing daily-goal style contract: ' + needle));
+
+[
+  "'累计目标': 'Cumulative goal'",
+  "'累计打卡目标': 'Cumulative check-in goal'",
+  "'高级设置': 'Advanced settings'",
+  "'小目标名称': 'Milestone name'",
+  "'未达成': 'Upcoming'",
+  "'天 · 可选': 'Days · optional'",
+  'days total · goal met',
+].forEach((needle) => assert(i18n.includes(needle), 'missing daily-goal translation contract: ' + needle));
+
+console.log('daily goal contract: ok');

--- a/tests/test_daily_goals.py
+++ b/tests/test_daily_goals.py
@@ -1,0 +1,164 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import app
+
+
+class DailyGoalTests(unittest.TestCase):
+    def setUp(self):
+        self.original_daily_file = app.DAILY_FILE
+        self.temp_dir = tempfile.TemporaryDirectory()
+        app.DAILY_FILE = Path(self.temp_dir.name) / "daily.json"
+
+    def tearDown(self):
+        app.DAILY_FILE = self.original_daily_file
+        self.temp_dir.cleanup()
+
+    def test_legacy_v3_task_defaults_to_no_cumulative_goal(self):
+        app.DAILY_FILE.write_text(json.dumps({
+            "version": 3,
+            "date": app._today_iso(),
+            "tasks": [{
+                "id": "legacy",
+                "name": "旧任务",
+                "targetMinutes": 25,
+                "totalDays": 7,
+                "doneDates": [],
+            }],
+            "groups": [],
+        }), encoding="utf-8")
+
+        loaded = app.load_daily()
+        public = app.daily_public_payload(loaded)
+
+        self.assertEqual(loaded["version"], 3)
+        self.assertEqual(loaded["tasks"][0]["targetDays"], 0)
+        self.assertEqual(loaded["tasks"][0]["milestones"], [])
+        self.assertEqual(public["tasks"][0]["targetDays"], 0)
+        self.assertEqual(public["tasks"][0]["milestones"], [])
+        self.assertEqual(public["tasks"][0]["totalDays"], 7)
+
+    def test_create_update_cap_and_clear_cumulative_goal(self):
+        created = app.daily_create({"name": "阅读", "targetDays": 30})
+        task_id = created["tasks"][0]["id"]
+        self.assertEqual(created["tasks"][0]["targetDays"], 30)
+
+        capped = app.daily_update({"id": task_id, "targetDays": 999999})
+        self.assertEqual(capped["tasks"][0]["targetDays"], app.DAILY_GOAL_DAYS_MAX)
+
+        cleared = app.daily_update({"id": task_id, "targetDays": ""})
+        self.assertEqual(cleared["tasks"][0]["targetDays"], 0)
+
+        normalized = app.daily_update({"id": task_id, "targetDays": -10})
+        self.assertEqual(normalized["tasks"][0]["targetDays"], 0)
+
+    def test_check_in_and_undo_preserve_cumulative_goal(self):
+        created = app.daily_create({
+            "name": "练习",
+            "targetDays": 100,
+            "milestones": [{"name": "起步", "days": 1}, {"name": "毕业", "days": 100}],
+        })
+        task_id = created["tasks"][0]["id"]
+        milestones = created["tasks"][0]["milestones"]
+
+        checked = app.daily_toggle({"id": task_id, "done": True})
+        self.assertTrue(checked["tasks"][0]["doneToday"])
+        self.assertEqual(checked["tasks"][0]["totalDays"], 1)
+        self.assertEqual(checked["tasks"][0]["targetDays"], 100)
+        self.assertEqual(checked["tasks"][0]["milestones"], milestones)
+
+        undone = app.daily_toggle({"id": task_id, "done": False})
+        self.assertFalse(undone["tasks"][0]["doneToday"])
+        self.assertEqual(undone["tasks"][0]["totalDays"], 0)
+        self.assertEqual(undone["tasks"][0]["targetDays"], 100)
+        self.assertEqual(undone["tasks"][0]["milestones"], milestones)
+
+        focused = app.daily_add_minutes({"id": task_id, "minutes": 25})
+        self.assertEqual(focused["tasks"][0]["milestones"], milestones)
+
+    def test_create_and_update_six_sorted_milestones_with_stable_ids(self):
+        source = [
+            {"id": "finish", "name": "毕业", "days": 100},
+            {"name": "第一周", "days": 7},
+            {"name": "第一个月", "days": 30},
+            {"name": "稳定", "days": 60},
+            {"name": "起步", "days": 1},
+            {"name": "半程", "days": 50},
+        ]
+        created = app.daily_create({"name": "阅读", "targetDays": 100, "milestones": source})
+        task = created["tasks"][0]
+        self.assertEqual([item["days"] for item in task["milestones"]], [1, 7, 30, 50, 60, 100])
+        self.assertEqual(task["milestones"][-1]["id"], "finish")
+        self.assertTrue(all(item["id"] for item in task["milestones"]))
+
+        renamed = [dict(item) for item in task["milestones"]]
+        renamed[1]["name"] = "坚持一周"
+        updated = app.daily_update({"id": task["id"], "milestones": renamed})["tasks"][0]
+        self.assertEqual(updated["milestones"][1]["name"], "坚持一周")
+        self.assertEqual(updated["milestones"][1]["id"], task["milestones"][1]["id"])
+
+        cleared = app.daily_update({"id": task["id"], "milestones": []})["tasks"][0]
+        self.assertEqual(cleared["milestones"], [])
+
+    def test_rejects_invalid_milestones_and_target_conflicts_atomically(self):
+        created = app.daily_create({
+            "name": "运动",
+            "targetDays": 30,
+            "milestones": [{"id": "week", "name": "第一周", "days": 7}],
+        })
+        task_id = created["tasks"][0]["id"]
+        invalid_sets = [
+            [{"name": str(index), "days": index + 1} for index in range(7)],
+            [{"name": "", "days": 1}],
+            [{"name": "x" * 41, "days": 1}],
+            [{"name": "一", "days": 7}, {"name": "二", "days": 7}],
+            [{"name": "零", "days": 0}],
+            [{"name": "小数", "days": 1.5}],
+            [{"name": "超出", "days": 31}],
+        ]
+        for milestones in invalid_sets:
+            with self.subTest(milestones=milestones):
+                with self.assertRaises(ValueError):
+                    app.daily_update({"id": task_id, "milestones": milestones})
+                current = app.daily_public_payload()["tasks"][0]
+                self.assertEqual(current["targetDays"], 30)
+                self.assertEqual(current["milestones"][0]["id"], "week")
+
+        with self.assertRaises(ValueError):
+            app.daily_update({"id": task_id, "targetDays": 5})
+        with self.assertRaises(ValueError):
+            app.daily_update({"id": task_id, "targetDays": 0})
+        current = app.daily_public_payload()["tasks"][0]
+        self.assertEqual(current["targetDays"], 30)
+        self.assertEqual(current["milestones"][0]["days"], 7)
+
+    def test_load_safely_cleans_corrupt_milestones(self):
+        app.DAILY_FILE.write_text(json.dumps({
+            "version": 3,
+            "date": app._today_iso(),
+            "tasks": [{
+                "id": "corrupt",
+                "name": "旧任务",
+                "targetDays": 30,
+                "milestones": [
+                    {"id": "valid", "name": " 第一周 ", "days": 7},
+                    {"id": "duplicate", "name": "重复", "days": 7},
+                    {"name": "越界", "days": 31},
+                    {"name": "", "days": 8},
+                    {"name": "x" * 60, "days": 10},
+                ],
+            }],
+            "groups": [],
+        }), encoding="utf-8")
+
+        task = app.load_daily()["tasks"][0]
+        self.assertEqual([item["days"] for item in task["milestones"]], [7, 10])
+        self.assertEqual(task["milestones"][0], {"id": "valid", "name": "第一周", "days": 7})
+        self.assertEqual(len(task["milestones"][1]["name"]), app.DAILY_MILESTONE_NAME_MAX)
+        self.assertTrue(task["milestones"][1]["id"].startswith("dm_"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add optional cumulative check-in goals to daily tasks
- add up to six named milestones with validation, progress markers, dark-mode styling, and bilingual UI copy
- preserve atomic backend updates and compatibility with existing v3 daily-task data
- add Python unit tests, frontend contract coverage, and CI execution
- update the repository maintenance guide to document the data contract

## Why

Daily tasks previously tracked total completion days but offered no long-term target or intermediate milestones. This adds a structured goal layer while keeping daily minute targets and existing history intact.

## Validation

- `python -m unittest tests.test_daily_goals`
- `node tests/daily-goal-contract.js`
- `python -m py_compile app.py ai_plan.py desktop.py windows_wallpaper.py`
- `node --check` for all non-vendor JavaScript under `assets/`