### PR TITLE
Add desktop single-instance coordination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 | `app.py` | 本地 HTTP 服务、路由、持久化、导入导出、AI 代理、独立复习卡片数据库、学习/日历/速记/专注数据。 |
 | `ai_plan.py` | AI 助手 V2 的纯标准库计划层；集中维护紧凑提示词、JSON 提取、动作协议、安全校验和结构修复提示，不写用户数据。 |
 | `desktop.py` | pywebview 桌面壳、WebView2 检测、无边框窗口、窗口状态、未保存关闭确认和动态背景生命周期协调。 |
+| `desktop_instance.py` | Windows 桌面主程序单实例协调；按数据根持有命名互斥锁，通过带认证的本地命名管道转交窗口激活或 `.canvas` 打开请求，并管理 `%TEMP%` 中的短期状态文件。 |
 | `windows_wallpaper.py` | Windows 倒数日动态桌面背景宿主；由主进程管理托盘与生命周期，并从同一个 `Relatum.exe` 启动隔离的只读 WebView2 子进程，严格挂载到 Explorer 的专用全屏 `WorkerW`，同时负责主屏尺寸跟踪、单背景互斥、进程间通信和安全清理。 |
 | `build-desktop.ps1` | PyInstaller onedir 便携版打包，输出 `Relatum-release/Relatum.exe`。脚本保持 ASCII。 |
 | `build-msix.ps1` | Microsoft Store x64 MSIX 打包；复用便携版产物，生成匹配商店身份的清单与图标，输出 `Relatum-store/*.msixupload`。脚本保持 ASCII。 |
@@ -480,6 +481,8 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 
 - 桌面方案是 pywebview + WebView2，不是 Electron。
 - `desktop.py` 会先启动本地服务，再打开 `index.html?desktop=1` 或 `editor.html?desktop=1&file=...`。
+- Windows 普通桌面启动按 `ROOT` 保持一个主实例：第二次启动不再创建服务和 WebView2，而是通过 `desktop_instance.py` 的本地认证命名管道唤醒已有窗口。传入另一张有效 `.canvas` 时，当前窗口干净才在原窗口切换；当前画布 dirty 时只唤醒并拒绝切换；传入同一画布只唤醒、不刷新。窗口尚未就绪时只保留最后一条有效请求。动态背景子进程及 `--no-browser` / `--port` / `--allow-dir` 服务模式不参与这项主实例限制。
+- 主实例状态只短期写在 `%TEMP%/relatum-desktop-<ROOT哈希>.json`，含随机管道和认证材料；正常退出仅删除仍属于自己的状态，异常退出后的陈旧文件由下一主实例覆盖。IPC 只接受窗口激活与已重新验证的 `.canvas` 路径，不得扩成通用控制面。
 - Windows 下做了无边框窗口：隐藏原生标题栏、保留系统最小化/最大化动画、DWM 圆角、关闭时检查 dirty。
 - `desktop-shell.js` 负责窗口按钮、pywebview ready 队列、dirty 标记和桌面 session 标识。
 - 倒数日动态背景仍只发布一个 `Relatum.exe`，但背景 WebView2 必须由该 EXE 的隔离子进程承载，不能再与主窗口共享 WinForms UI 线程。主进程通过本地 Windows 命名管道管理启动、切换、删除通知和停止，并独立持有托盘与数据根互斥锁。子进程向 `Progman` 请求一次桌面壁纸宿主后，必须找到拥有 `SHELLDLL_DefView` 的顶层窗口及其后方、同属 Explorer 且覆盖主屏的专用 `WorkerW`；`SHELLDLL_DefView` / `SysListView32` 会绘制静态壁纸，绝不能作为背景父窗口，也不能按类名选择任意小型 `WorkerW`。挂载成功后才允许主进程返回 `active:true`；不能调用会强制 `Activate()` 的 `window.show()`。它不替换系统静态壁纸，只支持 Windows 主显示器和本次运行，不自启、不持久化。动态背景启用时关闭主窗只隐藏到托盘；托盘“取消桌面背景”会停止子进程并重新显示主窗，“退出 Relatum”仍执行 dirty 确认。子进程启动失败、Explorer 宿主丢失或同一数据根已有背景实例时必须安全停止，不能留下普通悬窗或虚假的启用状态。
@@ -499,7 +502,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 Python 改动：
 
 ```powershell
-python -m py_compile .\app.py .\ai_plan.py .\desktop.py .\windows_wallpaper.py .\packaging\make_icon.py .\packaging\make_font_subset.py
+python -m py_compile .\app.py .\ai_plan.py .\desktop.py .\desktop_instance.py .\windows_wallpaper.py .\packaging\make_icon.py .\packaging\make_font_subset.py
 ```
 
 改动 AI 计划协议、提示词、结构修复或 OpenAI 兼容参数降级时，还要运行：
@@ -634,6 +637,7 @@ Invoke-WebRequest http://127.0.0.1:8799/api/runtime
 
 - 先读 `README.md` 的“构建 Windows 桌面版”章节。
 - 只在用户要求或任务确实需要时运行 `build-desktop.ps1`。
+- 改动主实例、窗口激活或桌面 IPC 时运行 `python -m unittest .\tests\test_desktop_instance.py .\tests\test_windows_wallpaper.py .\tests\test_runtime_paths.py`，并用同一数据根连续启动多次验证只有一个主窗口；WebView2 的浏览器/GPU/渲染器子进程不算重复主实例。
 - 验收 `Relatum-release/Relatum.exe`、同级 `Relatum.exe.config`、`_internal/assets/`，确认没有把 `AI笔记创作指南.md`、`canvases/` 或 `data/` 打进包里。
 
 ## 12. 常见坑

--- a/desktop.py
+++ b/desktop.py
@@ -21,6 +21,7 @@ from ctypes import wintypes
 from pathlib import Path
 
 import app
+from desktop_instance import DesktopInstanceCoordinator
 from windows_wallpaper import WallpaperController, run_wallpaper_child
 
 try:
@@ -509,6 +510,107 @@ def _open_url(port: int, initial_file: Path | None) -> str:
     return base + "editor.html?desktop=1&file=" + urllib.parse.quote(str(initial_file))
 
 
+def _current_window_canvas(window) -> Path | None:
+    """Return the canvas currently shown by the desktop window, if any."""
+    import urllib.parse
+
+    try:
+        current_url = str(window.get_current_url() or "")
+        parsed = urllib.parse.urlparse(current_url)
+        if not parsed.path.endswith("/editor.html"):
+            return None
+        raw = urllib.parse.parse_qs(parsed.query).get("file", [""])[0]
+        if not raw:
+            return None
+        return Path(raw).resolve()
+    except (OSError, TypeError, ValueError):
+        return None
+
+
+class DesktopActivationRouter:
+    """Validate and apply activation commands received from later launches."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._window = None
+        self._bridge: DesktopBridge | None = None
+        self._port = 0
+        self._show_main = None
+        self._ready = False
+        self._pending: dict | None = None
+
+    def attach(self, window, bridge: DesktopBridge, port: int, show_main) -> None:
+        with self._lock:
+            self._window = window
+            self._bridge = bridge
+            self._port = int(port)
+            self._show_main = show_main
+
+    def mark_ready(self) -> None:
+        with self._lock:
+            self._ready = True
+            pending, self._pending = self._pending, None
+        if pending is not None:
+            self._apply(pending)
+
+    def handle(self, command: dict) -> dict:
+        raw = str(command.get("file") or "").strip()
+        target = None
+        if raw:
+            try:
+                candidate = Path(raw).resolve()
+            except OSError:
+                candidate = Path()
+            if candidate.suffix.lower() != ".canvas" or not candidate.is_file():
+                return {
+                    "ok": False,
+                    "status": "invalid-file",
+                    "error": "要打开的画布不存在或格式无效",
+                }
+            target = candidate
+        normalized = {"file": str(target) if target is not None else ""}
+        with self._lock:
+            if not self._ready or self._window is None or self._bridge is None:
+                self._pending = normalized
+                return {"ok": True, "status": "queued"}
+        return self._apply(normalized)
+
+    def _apply(self, command: dict) -> dict:
+        with self._lock:
+            window = self._window
+            bridge = self._bridge
+            port = self._port
+            show_main = self._show_main
+        if window is None or bridge is None or not port or show_main is None:
+            return {"ok": False, "status": "unavailable", "error": "主窗口尚未准备好"}
+
+        show_main()
+        raw = str(command.get("file") or "").strip()
+        if not raw:
+            return {"ok": True, "status": "activated"}
+        target = Path(raw)
+        if not target.is_file() or target.suffix.lower() != ".canvas":
+            return {"ok": False, "status": "invalid-file", "error": "要打开的画布已不存在"}
+
+        current = _current_window_canvas(window)
+        if current is not None and os.path.normcase(str(current)) == os.path.normcase(str(target)):
+            return {"ok": True, "status": "activated"}
+        with bridge._lock:
+            dirty = bridge.dirty
+        if dirty:
+            return {
+                "ok": True,
+                "status": "blocked-dirty",
+                "error": "当前画布还有未保存的修改",
+            }
+        try:
+            app.register_recent(target)
+            window.load_url(_open_url(port, target))
+        except Exception as err:
+            return {"ok": False, "status": "open-failed", "error": str(err)}
+        return {"ok": True, "status": "opened"}
+
+
 def _wallpaper_url(port: int, event_id: str, language: str) -> str:
     import urllib.parse
     return (f"http://127.0.0.1:{port}/countdown.html?wallpaper=1&event="
@@ -565,8 +667,38 @@ def main() -> int:
         )
         return 1
 
-    app.ensure_dirs()
     initial_file = app.resolve_initial_file(args.file)
+    activation_router = DesktopActivationRouter()
+    instance = DesktopInstanceCoordinator(app.ROOT, activation_router.handle)
+    try:
+        instance_result = instance.acquire_or_forward(initial_file)
+    except Exception as err:
+        _message_box(f"Relatum 单实例协调启动失败：\n{err}", 0x10)
+        return 1
+    if not instance_result.get("primary"):
+        status = str(instance_result.get("status") or "")
+        if status == "blocked-dirty":
+            _message_box(
+                "Relatum 已在运行。\n\n当前窗口有未保存的修改，已保留当前画布，未切换到另一张画布。",
+                0x30,
+            )
+            return 0
+        if not instance_result.get("ok"):
+            detail = str(instance_result.get("error") or "主实例暂不可用")
+            _message_box(
+                "Relatum 已在运行或正在启动，但暂时无法唤醒。\n\n"
+                f"请稍后重试。\n\n{detail}",
+                0x30,
+            )
+            return 1
+        return 0
+
+    try:
+        app.ensure_dirs()
+    except Exception as err:
+        instance.close()
+        _message_box(f"Relatum 数据目录初始化失败：\n{err}", 0x10)
+        return 1
     if initial_file is not None:
         app.register_recent(initial_file)
 
@@ -575,6 +707,7 @@ def main() -> int:
         port = app.find_free_port(app.DEFAULT_PORT)
         server = app.CanvasServer(("127.0.0.1", port), app.Handler)
     except Exception as err:
+        instance.close()
         _message_box(f"Relatum 启动失败：\n{err}", 0x10)
         return 1
     # selector 会在请求到达时立即唤醒；poll_interval 只影响 shutdown 检查。
@@ -631,6 +764,7 @@ def main() -> int:
         )
     except Exception as err:
         stop_server()
+        instance.close()
         _message_box(f"桌面窗口创建失败：\n{err}", 0x10)
         return 1
     bridge._window = window
@@ -647,6 +781,8 @@ def main() -> int:
                 ctypes.windll.user32.SetForegroundWindow(hwnd)
         except Exception:
             pass
+
+    activation_router.attach(window, bridge, port, show_main_window)
 
     def confirm_discard_changes() -> bool:
         with bridge._lock:
@@ -706,6 +842,7 @@ def main() -> int:
     def on_loaded() -> None:
         # 页面加载完成、WebView2 完成首次绘制后再补一次圆角，确保立即显形。
         _apply_corners(window, maximized=bridge.maximized)
+        activation_router.mark_ready()
 
     def on_maximized() -> None:
         bridge.maximized = True
@@ -763,6 +900,7 @@ def main() -> int:
         if bridge.wallpaper is not None:
             bridge.wallpaper.stop()
         stop_server()
+        instance.close()
     return 0
 
 

--- a/desktop_instance.py
+++ b/desktop_instance.py
@@ -1,0 +1,345 @@
+"""Windows desktop single-instance coordination for Relatum.
+
+The desktop shell stays single-instance per writable Relatum data root.  A
+short-lived secondary process forwards one narrowly-scoped activation command
+through an authenticated local named pipe, then exits.  Browser/server debug
+mode and the wallpaper child deliberately bypass this module.
+"""
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import json
+import os
+import secrets
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from multiprocessing.connection import Client, Listener
+from pathlib import Path
+from typing import Callable
+
+
+PROTOCOL_VERSION = 1
+ERROR_ALREADY_EXISTS = 183
+DEFAULT_FORWARD_TIMEOUT = 4.0
+DEFAULT_RETRY_INTERVAL = 0.1
+
+
+def instance_root_key(root: Path) -> str:
+    normalized = os.path.normcase(str(Path(root).resolve()))
+    return hashlib.sha256(os.fsencode(normalized)).hexdigest()[:24]
+
+
+def instance_state_path(root: Path, temp_dir: Path | None = None) -> Path:
+    base = Path(temp_dir) if temp_dir is not None else Path(tempfile.gettempdir())
+    return base / f"relatum-desktop-{instance_root_key(root)}.json"
+
+
+class DesktopInstanceCoordinator:
+    """Own the primary-instance mutex and authenticated activation pipe."""
+
+    def __init__(
+        self,
+        root: Path,
+        command_handler: Callable[[dict], dict],
+        *,
+        temp_dir: Path | None = None,
+        listener_factory=Listener,
+        client_factory=Client,
+        kernel32=None,
+        user32=None,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+        forward_timeout: float = DEFAULT_FORWARD_TIMEOUT,
+        retry_interval: float = DEFAULT_RETRY_INTERVAL,
+    ) -> None:
+        self.root = Path(root).resolve()
+        self.root_key = instance_root_key(self.root)
+        self.command_handler = command_handler
+        self.state_path = instance_state_path(self.root, temp_dir)
+        self.listener_factory = listener_factory
+        self.client_factory = client_factory
+        self.kernel32 = kernel32
+        self.user32 = user32
+        self.monotonic = monotonic
+        self.sleep = sleep
+        self.forward_timeout = max(0.1, float(forward_timeout))
+        self.retry_interval = max(0.01, float(retry_interval))
+
+        self._mutex = None
+        self._listener = None
+        self._listener_thread: threading.Thread | None = None
+        self._pipe_name = ""
+        self._authkey = b""
+        self._token = ""
+        self._stop_event = threading.Event()
+        self._close_lock = threading.Lock()
+        self._closed = False
+
+    def acquire_or_forward(self, file_path: Path | None) -> dict:
+        """Become primary, or forward activation to the existing primary."""
+        if sys.platform != "win32":
+            return {"primary": True, "ok": True, "status": "unsupported"}
+
+        kernel32 = self.kernel32 or ctypes.windll.kernel32
+        self._configure_kernel32(kernel32)
+        kernel32.SetLastError(0)
+        handle = kernel32.CreateMutexW(
+            None, False, f"Local\\RelatumMain-{self.root_key}",
+        )
+        if not handle:
+            raise OSError("无法创建 Relatum 单实例互斥锁")
+        already_exists = int(kernel32.GetLastError()) == ERROR_ALREADY_EXISTS
+        if already_exists:
+            kernel32.CloseHandle(handle)
+            command = {
+                "type": "activate",
+                "file": str(file_path) if file_path is not None else "",
+            }
+            return {"primary": False, **self._forward(command)}
+
+        self._mutex = handle
+        try:
+            self._start_listener()
+        except Exception:
+            self.close()
+            raise
+        return {"primary": True, "ok": True, "status": "primary"}
+
+    @staticmethod
+    def _configure_kernel32(kernel32) -> None:
+        signatures = (
+            ("CreateMutexW", [ctypes.c_void_p, ctypes.c_bool, ctypes.c_wchar_p], ctypes.c_void_p),
+            ("CloseHandle", [ctypes.c_void_p], ctypes.c_bool),
+            ("SetLastError", [ctypes.c_uint32], None),
+            ("GetLastError", [], ctypes.c_uint32),
+        )
+        for name, argtypes, restype in signatures:
+            function = getattr(kernel32, name)
+            try:
+                function.argtypes = argtypes
+                function.restype = restype
+            except (AttributeError, TypeError):
+                pass
+
+    def _start_listener(self) -> None:
+        self._authkey = secrets.token_bytes(32)
+        self._token = uuid.uuid4().hex
+        self._pipe_name = rf"\\.\pipe\RelatumMain-{self.root_key}-{uuid.uuid4().hex}"
+        listener = self.listener_factory(
+            self._pipe_name, family="AF_PIPE", authkey=self._authkey,
+        )
+        self._listener = listener
+        self._write_state({
+            "version": PROTOCOL_VERSION,
+            "rootKey": self.root_key,
+            "pid": os.getpid(),
+            "pipe": self._pipe_name,
+            "auth": self._authkey.hex(),
+            "token": self._token,
+        })
+        thread = threading.Thread(
+            target=self._listener_loop,
+            args=(listener,),
+            name="relatum-desktop-instance-ipc",
+            daemon=True,
+        )
+        self._listener_thread = thread
+        thread.start()
+
+    def _write_state(self, state: dict) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        temp = self.state_path.with_name(
+            f".{self.state_path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+        )
+        try:
+            temp.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+            os.replace(temp, self.state_path)
+        finally:
+            try:
+                temp.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def _read_state(self) -> dict | None:
+        try:
+            state = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        if not isinstance(state, dict):
+            return None
+        if state.get("version") != PROTOCOL_VERSION or state.get("rootKey") != self.root_key:
+            return None
+        pipe = state.get("pipe")
+        auth = state.get("auth")
+        pid = state.get("pid")
+        if not isinstance(pipe, str) or not pipe.startswith(r"\\.\pipe\RelatumMain-"):
+            return None
+        if not isinstance(auth, str) or len(auth) != 64:
+            return None
+        if not isinstance(pid, int) or pid <= 0:
+            return None
+        try:
+            bytes.fromhex(auth)
+        except ValueError:
+            return None
+        return state
+
+    def _forward(self, command: dict) -> dict:
+        deadline = self.monotonic() + self.forward_timeout
+        last_error = ""
+        while True:
+            state = self._read_state()
+            if state is not None:
+                connection = None
+                try:
+                    self._allow_primary_foreground(state["pid"])
+                    connection = self.client_factory(
+                        state["pipe"], family="AF_PIPE", authkey=bytes.fromhex(state["auth"]),
+                    )
+                    connection.send(command)
+                    response = connection.recv()
+                    if isinstance(response, dict):
+                        return response
+                    last_error = "主实例返回了无效响应"
+                except (EOFError, OSError, ValueError) as err:
+                    last_error = str(err)
+                finally:
+                    if connection is not None:
+                        try:
+                            connection.close()
+                        except Exception:
+                            pass
+            if self.monotonic() >= deadline:
+                return {
+                    "ok": False,
+                    "status": "unavailable",
+                    "error": last_error or "主实例尚未准备好",
+                }
+            self.sleep(self.retry_interval)
+
+    def _allow_primary_foreground(self, pid: int) -> None:
+        """Transfer the user's foreground-launch permission to the primary."""
+        try:
+            user32 = self.user32 or ctypes.windll.user32
+            function = user32.AllowSetForegroundWindow
+            try:
+                function.argtypes = [ctypes.c_uint32]
+                function.restype = ctypes.c_bool
+            except (AttributeError, TypeError):
+                pass
+            function(int(pid))
+        except Exception:
+            pass
+
+    def _listener_loop(self, listener) -> None:
+        try:
+            while not self._stop_event.is_set():
+                connection = None
+                try:
+                    connection = listener.accept()
+                    message = connection.recv()
+                    if (
+                        isinstance(message, dict)
+                        and message.get("type") == "shutdown"
+                        and secrets.compare_digest(str(message.get("token") or ""), self._token)
+                    ):
+                        connection.send({"ok": True, "status": "stopping"})
+                        break
+                    if not isinstance(message, dict) or message.get("type") != "activate":
+                        response = {
+                            "ok": False, "status": "invalid-command",
+                            "error": "不支持的实例命令",
+                        }
+                    elif not isinstance(message.get("file", ""), str):
+                        response = {
+                            "ok": False, "status": "invalid-file",
+                            "error": "画布路径格式无效",
+                        }
+                    else:
+                        try:
+                            response = self.command_handler(message)
+                        except Exception as err:
+                            response = {
+                                "ok": False, "status": "handler-error", "error": str(err),
+                            }
+                        if not isinstance(response, dict):
+                            response = {
+                                "ok": False, "status": "invalid-response",
+                                "error": "主实例未返回有效结果",
+                            }
+                    connection.send(response)
+                except (EOFError, OSError):
+                    if self._stop_event.is_set():
+                        break
+                finally:
+                    if connection is not None:
+                        try:
+                            connection.close()
+                        except Exception:
+                            pass
+        finally:
+            try:
+                listener.close()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+        self._stop_event.set()
+        listener = self._listener
+        thread = self._listener_thread
+        if listener is not None and self._pipe_name and self._authkey:
+            connection = None
+            try:
+                connection = self.client_factory(
+                    self._pipe_name, family="AF_PIPE", authkey=self._authkey,
+                )
+                connection.send({"type": "shutdown", "token": self._token})
+                connection.recv()
+            except (EOFError, OSError):
+                pass
+            finally:
+                if connection is not None:
+                    try:
+                        connection.close()
+                    except Exception:
+                        pass
+        if listener is not None:
+            try:
+                listener.close()
+            except Exception:
+                pass
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=1.0)
+        self._remove_owned_state()
+        handle, self._mutex = self._mutex, None
+        if handle:
+            try:
+                kernel32 = self.kernel32 or ctypes.windll.kernel32
+                kernel32.CloseHandle(handle)
+            except Exception:
+                pass
+        self._listener = None
+        self._listener_thread = None
+
+    def _remove_owned_state(self) -> None:
+        try:
+            state = json.loads(self.state_path.read_text(encoding="utf-8"))
+            if not isinstance(state, dict) or state.get("token") != self._token:
+                return
+            self.state_path.unlink(missing_ok=True)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        self.close()

--- a/tests/test_desktop_instance.py
+++ b/tests/test_desktop_instance.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import tempfile
+import threading
+import unittest
+import urllib.parse
+from pathlib import Path
+from unittest import mock
+
+import desktop
+import desktop_instance
+
+
+class _PipeEndpoint:
+    def __init__(self, incoming, outgoing):
+        self.incoming = incoming
+        self.outgoing = outgoing
+        self.closed = False
+
+    def send(self, message):
+        self.outgoing.put(message)
+
+    def recv(self):
+        item = self.incoming.get(timeout=2)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    def close(self):
+        self.closed = True
+
+
+class _PipeListener:
+    def __init__(self, hub, address, authkey):
+        self.hub = hub
+        self.address = address
+        self.authkey = authkey
+        self.connections = queue.Queue()
+        self.closed = False
+
+    def accept(self):
+        item = self.connections.get(timeout=2)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    def close(self):
+        if not self.closed:
+            self.closed = True
+            self.connections.put(OSError("closed"))
+
+
+class _PipeHub:
+    def __init__(self):
+        self.listeners = {}
+
+    def listener(self, address, *, family, authkey):
+        self.assert_family(family)
+        listener = _PipeListener(self, address, authkey)
+        self.listeners[address] = listener
+        return listener
+
+    def client(self, address, *, family, authkey):
+        self.assert_family(family)
+        listener = self.listeners.get(address)
+        if listener is None or listener.closed or listener.authkey != authkey:
+            raise OSError("pipe unavailable")
+        client_in = queue.Queue()
+        server_in = queue.Queue()
+        client = _PipeEndpoint(client_in, server_in)
+        server = _PipeEndpoint(server_in, client_in)
+        listener.connections.put(server)
+        return client
+
+    @staticmethod
+    def assert_family(family):
+        if family != "AF_PIPE":
+            raise AssertionError(family)
+
+
+class _FakeKernel32:
+    def __init__(self):
+        self.last_error = 0
+        self.next_handle = 100
+        self.handles = {}
+        self.counts = {}
+
+    def SetLastError(self, value):
+        self.last_error = int(value)
+
+    def GetLastError(self):
+        return self.last_error
+
+    def CreateMutexW(self, _security, _owner, name):
+        self.next_handle += 1
+        handle = self.next_handle
+        self.last_error = desktop_instance.ERROR_ALREADY_EXISTS if self.counts.get(name) else 0
+        self.counts[name] = self.counts.get(name, 0) + 1
+        self.handles[handle] = name
+        return handle
+
+    def CloseHandle(self, handle):
+        name = self.handles.pop(handle, None)
+        if name is not None:
+            self.counts[name] -= 1
+            if self.counts[name] <= 0:
+                self.counts.pop(name, None)
+        return True
+
+
+class _FakeUser32:
+    def __init__(self):
+        self.allowed = []
+
+    def AllowSetForegroundWindow(self, pid):
+        self.allowed.append(int(pid))
+        return True
+
+
+class DesktopInstanceCoordinatorTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.temp_path = Path(self.temp.name)
+        self.kernel = _FakeKernel32()
+        self.user = _FakeUser32()
+        self.hub = _PipeHub()
+        self.platform_patch = mock.patch.object(desktop_instance.sys, "platform", "win32")
+        self.platform_patch.start()
+        self.addCleanup(self.platform_patch.stop)
+
+    def coordinator(self, root, handler, **kwargs):
+        return desktop_instance.DesktopInstanceCoordinator(
+            root,
+            handler,
+            temp_dir=self.temp_path,
+            listener_factory=self.hub.listener,
+            client_factory=kwargs.pop("client_factory", self.hub.client),
+            kernel32=self.kernel,
+            user32=self.user,
+            forward_timeout=kwargs.pop("forward_timeout", 0.3),
+            retry_interval=kwargs.pop("retry_interval", 0.01),
+            **kwargs,
+        )
+
+    def test_secondary_forwards_to_primary_and_cleanup_allows_restart(self):
+        commands = []
+        root = self.temp_path / "runtime"
+        primary = self.coordinator(
+            root,
+            lambda command: commands.append(command) or {"ok": True, "status": "activated"},
+        )
+        self.addCleanup(primary.close)
+        self.assertTrue(primary.acquire_or_forward(None)["primary"])
+        self.assertTrue(primary.state_path.is_file())
+
+        secondary = self.coordinator(root, lambda _command: {})
+        result = secondary.acquire_or_forward(Path("sample.canvas"))
+        self.assertFalse(result["primary"])
+        self.assertEqual(result["status"], "activated")
+        self.assertEqual(commands[-1], {"type": "activate", "file": "sample.canvas"})
+        self.assertEqual(self.user.allowed[-1], os.getpid())
+
+        primary.close()
+        self.assertFalse(primary.state_path.exists())
+        replacement = self.coordinator(root, lambda _command: {})
+        self.addCleanup(replacement.close)
+        self.assertTrue(replacement.acquire_or_forward(None)["primary"])
+
+    def test_different_data_roots_have_independent_primaries(self):
+        first = self.coordinator(self.temp_path / "a", lambda _command: {})
+        second = self.coordinator(self.temp_path / "b", lambda _command: {})
+        self.addCleanup(first.close)
+        self.addCleanup(second.close)
+        self.assertTrue(first.acquire_or_forward(None)["primary"])
+        self.assertTrue(second.acquire_or_forward(None)["primary"])
+        self.assertNotEqual(first.root_key, second.root_key)
+
+    def test_secondary_retries_while_primary_finishes_starting(self):
+        primary = self.coordinator(
+            self.temp_path / "runtime",
+            lambda _command: {"ok": True, "status": "queued"},
+        )
+        self.addCleanup(primary.close)
+        self.assertTrue(primary.acquire_or_forward(None)["primary"])
+        attempts = []
+
+        def flaky_client(*args, **kwargs):
+            attempts.append(True)
+            if len(attempts) < 3:
+                raise OSError("not ready")
+            return self.hub.client(*args, **kwargs)
+
+        secondary = self.coordinator(
+            self.temp_path / "runtime", lambda _command: {}, client_factory=flaky_client,
+        )
+        result = secondary.acquire_or_forward(None)
+        self.assertFalse(result["primary"])
+        self.assertEqual(result["status"], "queued")
+        self.assertGreaterEqual(len(attempts), 3)
+
+    def test_invalid_state_times_out_without_starting_duplicate(self):
+        root = self.temp_path / "runtime"
+        mutex_name = f"Local\\RelatumMain-{desktop_instance.instance_root_key(root)}"
+        self.kernel.CreateMutexW(None, False, mutex_name)
+        state_path = desktop_instance.instance_state_path(root, self.temp_path)
+        state_path.write_text("not json", encoding="utf-8")
+        clock = [0.0]
+
+        def monotonic():
+            return clock[0]
+
+        def sleep(seconds):
+            clock[0] += seconds
+
+        secondary = self.coordinator(
+            root, lambda _command: {}, monotonic=monotonic, sleep=sleep,
+            forward_timeout=0.05, retry_interval=0.01,
+        )
+        result = secondary.acquire_or_forward(None)
+        self.assertFalse(result["primary"])
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["status"], "unavailable")
+
+    def test_cleanup_does_not_delete_newer_owner_state(self):
+        primary = self.coordinator(self.temp_path / "runtime", lambda _command: {})
+        self.assertTrue(primary.acquire_or_forward(None)["primary"])
+        state = json.loads(primary.state_path.read_text(encoding="utf-8"))
+        state["token"] = "new-owner"
+        primary.state_path.write_text(json.dumps(state), encoding="utf-8")
+        primary.close()
+        self.assertTrue(primary.state_path.exists())
+
+
+class _FakeWindow:
+    def __init__(self, url="http://127.0.0.1:8765/index.html?desktop=1"):
+        self.url = url
+        self.loaded = []
+
+    def get_current_url(self):
+        return self.url
+
+    def load_url(self, url):
+        self.url = url
+        self.loaded.append(url)
+
+
+class DesktopActivationRouterTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.first = self.root / "first.canvas"
+        self.second = self.root / "second.canvas"
+        self.first.write_text("{}", encoding="utf-8")
+        self.second.write_text("{}", encoding="utf-8")
+
+    def attached_router(self, current=None, dirty=False):
+        current_url = "http://127.0.0.1:8765/index.html?desktop=1"
+        if current is not None:
+            current_url = (
+                "http://127.0.0.1:8765/editor.html?desktop=1&file="
+                + urllib.parse.quote(str(current))
+            )
+        window = _FakeWindow(current_url)
+        bridge = desktop.DesktopBridge()
+        bridge.dirty = dirty
+        shown = []
+        router = desktop.DesktopActivationRouter()
+        router.attach(window, bridge, 8765, lambda: shown.append(True))
+        router.mark_ready()
+        return router, window, bridge, shown
+
+    def test_no_file_only_activates_existing_window(self):
+        router, window, _bridge, shown = self.attached_router()
+        result = router.handle({"file": ""})
+        self.assertEqual(result["status"], "activated")
+        self.assertEqual(shown, [True])
+        self.assertEqual(window.loaded, [])
+
+    def test_same_dirty_canvas_is_activated_without_reload(self):
+        router, window, _bridge, shown = self.attached_router(self.first, dirty=True)
+        result = router.handle({"file": str(self.first)})
+        self.assertEqual(result["status"], "activated")
+        self.assertEqual(shown, [True])
+        self.assertEqual(window.loaded, [])
+
+    def test_different_canvas_is_blocked_while_dirty(self):
+        router, window, _bridge, shown = self.attached_router(self.first, dirty=True)
+        with mock.patch.object(desktop.app, "register_recent") as register:
+            result = router.handle({"file": str(self.second)})
+        self.assertEqual(result["status"], "blocked-dirty")
+        self.assertEqual(shown, [True])
+        self.assertEqual(window.loaded, [])
+        register.assert_not_called()
+
+    def test_clean_window_opens_requested_canvas(self):
+        router, window, _bridge, shown = self.attached_router(self.first, dirty=False)
+        with mock.patch.object(desktop.app, "register_recent") as register:
+            result = router.handle({"file": str(self.second)})
+        self.assertEqual(result["status"], "opened")
+        self.assertEqual(shown, [True])
+        register.assert_called_once_with(self.second.resolve())
+        self.assertEqual(len(window.loaded), 1)
+        self.assertIn(urllib.parse.quote(str(self.second.resolve())), window.loaded[0])
+
+    def test_invalid_file_is_rejected(self):
+        router, window, _bridge, shown = self.attached_router()
+        result = router.handle({"file": str(self.root / "missing.canvas")})
+        self.assertEqual(result["status"], "invalid-file")
+        self.assertFalse(result["ok"])
+        self.assertEqual(shown, [])
+        self.assertEqual(window.loaded, [])
+
+    def test_last_startup_command_is_applied_when_window_becomes_ready(self):
+        router = desktop.DesktopActivationRouter()
+        self.assertEqual(router.handle({"file": str(self.first)})["status"], "queued")
+        self.assertEqual(router.handle({"file": str(self.second)})["status"], "queued")
+        window = _FakeWindow()
+        bridge = desktop.DesktopBridge()
+        shown = []
+        router.attach(window, bridge, 8765, lambda: shown.append(True))
+        with mock.patch.object(desktop.app, "register_recent") as register:
+            router.mark_ready()
+        register.assert_called_once_with(self.second.resolve())
+        self.assertEqual(len(window.loaded), 1)
+        self.assertEqual(shown, [True])
+
+
+class DesktopEntryBypassTests(unittest.TestCase):
+    def test_wallpaper_child_bypasses_main_instance_coordinator(self):
+        with mock.patch.object(desktop.sys, "argv", ["desktop.py", "--countdown-wallpaper-child"]), \
+                mock.patch.object(desktop, "_run_wallpaper_child_from_args", return_value=7), \
+                mock.patch.object(desktop, "DesktopInstanceCoordinator") as coordinator:
+            self.assertEqual(desktop.main(), 7)
+        coordinator.assert_not_called()
+
+    def test_service_mode_bypasses_main_instance_coordinator(self):
+        with mock.patch.object(desktop.sys, "argv", ["desktop.py", "--no-browser"]), \
+                mock.patch.object(desktop.app, "main", return_value=9), \
+                mock.patch.object(desktop, "DesktopInstanceCoordinator") as coordinator:
+            self.assertEqual(desktop.main(), 9)
+        coordinator.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Enforce one Relatum desktop main instance per data root.
- Forward activation and verified `.canvas` open requests over an authenticated local named pipe.
- Reuse the current window when clean, while preserving unsaved work by rejecting dirty-canvas switches.
- Keep wallpaper-child and explicit service/debug launch modes outside the desktop single-instance boundary.
- Add coordinator/router coverage and update the desktop runtime documentation.

## Why

Repeated desktop launches could create duplicate local services and WebView2 windows for the same data root. That increased memory use and introduced avoidable contention around the same user data. This change removes that main source of duplicate-client overhead without changing the canvas format, HTTP API, or rendering paths.

## Validation

- Full Python suite: 84 tests passed.
- Focused desktop suite: 23 tests passed.
- `canvas-performance-contract.js`: passed.
- Public repository safety check: passed (415 files checked).
- Rebuilt `Relatum-release` successfully.
- Packaged smoke test: five consecutive launches retained one main instance; forced termination recovered cleanly; forwarded canvas activation succeeded.