### PR TITLE
Add canvas activity tracking and Focus daily view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - Relatum / 画布项目 AI 接手指南
 
-> 最后按源码校准：2026-07-30。
+> 最后按源码校准：2026-08-09。
 > 这份文件是给后续 AI agent 的“接手地图”，不是历史任务流水账。若本文与源码冲突，以源码为准；改动功能后，要同步更新本文对应章节。
 
 ## 0. 先读这里
@@ -135,6 +135,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 | 起步页跨页便签 | `data/start-sticky-notes.json`，按 `recent/study/cadence/calendar/review/focus` 页面归属保存；不进入速记墙归档 |
 | 速记归档 | `data/学习归档/<时间>-速记归档/notes.json` |
 | 专注记录 | `data/focus.json` |
+| 画布活动账本 | `data/canvas-activity.json`（v1）；独立保存稳定画布 ID、受管路径变更、创建/修改历史标记和按本地日期拆分并合并去重的前台使用时间段，不写入 `.canvas`。首次建立时只从 `createdAt` / `updatedAt` 或文件时间回填事件，不伪造历史时长。 |
 | 每日任务 | `data/daily.json`，含汇总字段、可选累计打卡目标 `targetDays`、至多 6 个命名里程碑 `milestones[]` 与逐日历史 `doneDates` / `minutesByDate` |
 | 日记 | `data/diary/YYYY-MM-DD.md` |
 | 日历任务便签 | `data/calendar-pins.json` |
@@ -172,7 +173,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 - 笔记坞顶栏快捷入口偏好使用 `canvas:notebookTopbarShortcut`，未设置时默认关闭；开启后在“工具 / Tools”右侧显示“笔记 / Notes”，取消后立即隐藏。它只是一项全局编辑器 UI 偏好，不写入 `.canvas`。
 - 任务簿顶栏快捷入口偏好使用 `canvas:taskbookTopbarShortcut`，未设置时默认关闭；开启后显示“任务 / Tasks”，取消后立即隐藏。叶子任务悬停计时按钮偏好使用 `canvas:taskbookLeafTimerButtonsEnabled`，默认开启，仅显式 `'0'` 隐藏画布节点左侧的 `▶ / Ⅱ`，不影响顶级任务卡片、计时状态或任务数据。两者与任务簿归档副本偏好相互独立，均不写入 `.canvas`。
 - 空白框选创建盒子与框选节点创建分组分别由 `canvas:boxCreateEnabled` / `canvas:groupCreateEnabled` 控制，两个开关默认开启且彼此独立；`canvas:genIndexEnabled` 也必须独立判断，不能因关闭盒子或分组而隐藏框选生成索引入口。
-- 速记、学习、复习、专注各自有视图偏好和临时运行状态；复习方式使用 `canvas:reviewMode:v1` 记住 `scheduled` / `free`，只影响界面路径，不复制卡片数据或调度状态。
+- 速记、学习、复习、专注各自有视图偏好和临时运行状态；专注页使用 `focus:viewMode` 记住 `timer` / `daily`，每日任务完成页另用 `focus:dailyReviewedDate` 记住当天是否已经点击“回顾今日”（本地日期变化或当天撤销任一任务后失效）。普通进入时恢复上次视图，恢复未结束会话、从学习任务发起专注或从日历打开专注记录时只临时强制回到专注钟且不覆盖偏好。起始文档解析时会预载 `focus.js`，并行读取 `/api/daily`、`/api/focus` 与 `/api/study`；`focus.js` 先用这些结果填好隐藏 DOM，再发布 `CanvasFocus` 和 `canvasfocus:ready`。若用户更早点击，`start.js` 暂存首次激活及其外部任务/日期意图、保持旧页可见，等就绪后按“准备视图 → 翻页 → 入场”只执行一次，因此首次与后续进入使用同一份稳定数据和同一套动画，不能显示空专注壳或另播骨架动画；年度足迹使用 `canvas:cadenceLens:v2` 记住 `canvas` / `complete` / `focus`，没有 v2 偏好时默认“画布”，不沿用旧镜头偏好；复习方式使用 `canvas:reviewMode:v1` 记住 `scheduled` / `free`，只影响界面路径，不复制卡片数据或调度状态。
 - `sessionStorage` 的 `canvas:route-from-start` 用于从起步页进入编辑器后的返回/过渡体验。
 
 不要把这些偏好混进 `.canvas`，除非用户明确要求改变持久化设计。
@@ -183,7 +184,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 
 - 运行时与首页：`/api/runtime`、`/api/recent`
 - AI 配置安全视图：`/api/ai-config`
-- 学习/活跃：`/api/study`、`/api/study-activity`
+- 学习/活跃：`/api/study`、`/api/study-activity`；后者保留完成/专注数据，并返回 `canvasDays`、`canvasEntries`、`canvasStats`、`canvasGraph` 与 `canvasOverviewGraph`，年份是画布、完成归档和专注记录的并集。
 - 复习：`/api/review-pool`、`/api/review-cards`
 - 速记/跨页便签/专注/每日任务：`/api/notes`、`/api/start-sticky-notes`、`/api/focus`、`/api/daily`
 - 日历与倒数日：`/api/calendar`、`/api/countdown`
@@ -205,6 +206,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 - 复习：`/api/review-card-create`、`/api/review-card-update`、`/api/review-card-delete`、`/api/review-cards-batch`、`/api/review-cards-batch-delete`、`/api/review-deck-create`、`/api/review-deck-update`、`/api/review-deck-delete`、`/api/review-settings`、`/api/review-mark`
 - 速记、跨页便签和模板：`/api/notes-save`、`/api/notes-archive`、`/api/start-sticky-notes-save`、`/api/templates-save`
 - 专注：`/api/focus-log`、`/api/focus-session-update`、`/api/focus-session-delete`
+- 画布活动：`/api/canvas-activity` 接收已授权画布、会话 ID 与前台时间段；校验后按本地午夜拆分、与既有区间取并集，再返回本画布今日及累计秒数。
 - 每日任务：`/api/daily-create`、`/api/daily-update`、`/api/daily-delete`、`/api/daily-toggle`、`/api/daily-add-minutes`、`/api/daily-reorder`、`/api/daily-group-create`、`/api/daily-group-update`、`/api/daily-group-delete`、`/api/daily-tree`
 - 日历：`/api/diary-save`、`/api/diary-delete`、`/api/calendar-pins-save`、`/api/countdown-save`
 - AI：`/api/ai-chat`、`/api/ai-plan`、`/api/ai-test`、`/api/ai-config`
@@ -218,6 +220,11 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 - Windows 上，共用同一 `ROOT` 的多个 Relatum 服务还会通过命名互斥锁串行化写操作，避免两个实例把同一份 JSON 相互覆盖；进程内仍使用上述两把细分锁。非 Windows 源码运行目前只有进程内锁，不要误写成全平台单实例机制。
 
 ## 6. 画布编辑器契约
+
+### 前台使用时间
+
+- 主编辑器和学习页内嵌编辑器在画布完成初始化后开始累计当前画布前台时间；页面可见且窗口有焦点时持续计时，不设键鼠闲置超时。`blur`、页面隐藏、`pagehide`、离开或关闭时立即暂停并用 keepalive 结算，恢复前台后开启新时间段；平时每 30 秒向 `/api/canvas-activity` 提交增量，异常退出最多损失一个心跳周期。双屏只读参考查看器不单独计时。累计时长不占用编辑器顶栏，起步页“最近 / 收藏 / 分组”画布卡片只在悬停、键盘聚焦或键盘选中时于右下侧显示该画布累计前台时长。
+- 时间段由后端按会话 ID 接收并合并取并集；重复心跳、重试和多个窗口的重叠区间不得重复累计。新建、导入、保存只登记创建/修改事件，不按自动保存次数增加热力图时长；Relatum 内重命名、移入回收站和恢复要迁移同一账本身份。
 
 ### 首次使用引导
 
@@ -437,6 +444,11 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 ### 专注 `focus.js`
 
 - 支持番茄钟和正计时，运行状态存在 `localStorage`，刷新后可恢复。
+- 专注页有“专注钟 / 每日任务”两种内部视图；已在专注页时重复点击左侧“专”切换。每日任务是约 800px 宽的居中纸白卡片清单，分组使用可折叠标题分区和嵌套引导线，不再使用右侧把手、滑出侧栏或 Tab 开合。专注、暂停、休息和等待收尾均锁定在专注钟，完成收尾或重置后才允许切换；完成每日任务时原位保留，不能清场隐藏或自动收起所在分组。
+- `start.js` 在专注页参与外层书页过渡前必须先调用 `CanvasFocus.prepareActivate()` 同步确定 `hidden` / `inert` / `aria-hidden`；页面可见后再由 `activate()` 刷新，离开时由 `deactivate()` 取消过期请求、内部过渡、错峰计时器和拖拽临时态。每日任务有缓存时先显示旧 DOM 再静默刷新，数据签名未变不重建也不重播入场；首载无缓存时使用稳定卡片骨架。所有读取使用请求序号和 `AbortController`，每日任务写操作会使更早的后台读取失效，避免旧快照回写。
+- 专注钟与每日任务共享一个固定为 `minmax(0, 1fr)` 的 grid 叠层，根容器不滚动；计时器层可独立滚动，每日任务外层固定不滚动，只由居中约 800px 的 `.focus-daily-scroll` 承担纵向滚动，并隐藏原生滚动条但保留滚轮、触控和键盘滚动。交叉过渡期间较长清单不得撑高计时器层，也不得因滚动条占位改变标题、加号或卡片宽度。内部视图层切换只改变透明度；每日任务的页首、分组和卡片允许使用有限的纵向位移与轻微缩放弹性错峰，但必须以恒等位置收尾，不能影响 grid 尺寸。首次无缓存进入时，页首与随后到达的任务数据共用同一个 entrance generation：骨架只负责退场，禁止再给整个列表叠加第二套揭示动画。完成态不再降低整张卡片透明度，正文弱化通过可过渡的内容层完成，完成/撤销反馈只使用勾选、划线和卡片边缘的一次性动画，不能给任务摘要文字添加闪烁脉冲。
+- 专注钟桌面稳态在共享 grid 中使用固定的轻微右下相对偏移，≤900px 恢复无偏移；标题、工作台、控制区与计时环的重新入场只做透明度和环形进度绘制，不使用位移或缩放，避免外层翻页结束后仍发生第二次位置收尾。
+- 每日任务全部完成且当天尚未回顾时，隐藏普通“今天 n / n 完成”汇总，在 `.focus-daily-scroll` 之外显示覆盖整个专注内容区的高不透明度“微光聚星”庆祝层；左侧书脊保持可用，庆祝不受任务数量、滚动位置或列表裁剪影响。初载或重新进入已完成清单只显示静态态且不得主动聚焦“回顾今日”，避免翻页后无端出现焦点圈；仅当前交互由未完成跨到全部完成时，才先按可见顺序自下而上反向错峰、缓慢淡出任务卡与页首，再衔接光点汇聚、主星回弹、文字和按钮入场，交互庆祝完成前可把键盘焦点交给按钮。按钮约 260ms 交叉退场后恢复原清单、原滚动位置及最后完成任务的焦点，并在当天持久化回顾日期。庆祝 phase 固定为 `hidden / entering / visible / leaving`，期间底层清单必须 `inert` 且对辅助技术隐藏；接口确认同一完成态时只更新文案，不能中断 `entering` 或回顾退场，任一撤销清除当天回顾日期并收起覆盖层。所有计时器受 generation 保护，快速反复勾选或请求回滚必须以最新状态为准，低动态模式直接切换静态态；覆盖层与滚动区均不得使用持续模糊或常驻 `will-change`。
 - 可绑定学习任务或每日任务。专注完成后写入 `data/focus.json`，并同步任务统计。
 - 支持音效、柔和噪音、时长偏好、目标/收尾记录、记录编辑/删除、Zen 模式。
 - 每日任务是独立清单 `data/daily.json`，每天重置勾选状态，但累计天数和分钟保留；v3 起每条任务记录 `doneDates` / `minutesByDate`，用于专注页任务打卡日历，并可用 `targetDays` 设置基于历史 `totalDays` 的累计打卡目标（`0` 表示未设置，上限 3660 天）。可选 `milestones:[{id,name,days}]` 保存至多 6 个命名小目标，天数必须唯一且位于 `1..targetDays`，达成态只由 `totalDays >= days` 推导；高级设置先写任务编辑草稿，最后与总目标一起经 `/api/daily-update` 原子保存。任务卡和详情长期进度条以非按钮圆印章显示节点，悬停/键盘聚焦显示即时说明，桌面点击无操作、触屏轻触只揭示说明；今日分钟目标仍保留在编辑器与详情面板。
@@ -533,6 +545,15 @@ node --check .\assets\review.js
 ```
 
 只检查改过的手写 JS；不要对 `assets/vendor/` 里的压缩库做人工格式化或随意 check。
+改动画布前台计时、年度足迹“画布”镜头或画布活动账本时，还要运行：
+
+```powershell
+python -m unittest .\tests\test_canvas_activity.py
+node .\tests\canvas-activity-contract.js
+```
+
+并使用隔离的 `RELATUM_DATA_ROOT` 启动本地服务，实际验证编辑器前台计时、失焦暂停、活动页默认镜头、镜头记忆、热力日详情和画布星图；结束后关闭测试服务，不得读写真实用户账本。
+
 改动简洁画布样式面板的线型入口时，还要运行：
 
 ```powershell

--- a/app.py
+++ b/app.py
@@ -96,7 +96,8 @@ STUDY_ARCHIVE_DIR = DATA / "学习归档"
 CANVAS_ARCHIVE_DIR = DATA / "画布归档"   # 编辑器顶栏「归档」：移走划线节点 + 这里留轻量记录
 NOTES_FILE = DATA / "notes.json"   # 起步页「速记」便签墙（独立数据，不进 .canvas）
 START_STICKY_NOTES_FILE = DATA / "start-sticky-notes.json"   # 起步页跨页便签（不含「速记」页）
-FOCUS_FILE = DATA / "focus.json"   # 起步页「专注钟」专注记录（自成一体，不进 .canvas、不接活跃页）
+FOCUS_FILE = DATA / "focus.json"   # 起步页「专注钟」专注记录（自成一体，不进 .canvas；供活跃页专注镜头汇总）
+CANVAS_ACTIVITY_FILE = DATA / "canvas-activity.json"   # 画布前台使用时长与创建/修改足迹（不写进 .canvas）
 DAILY_FILE = DATA / "daily.json"   # 专注页「每日任务」习惯清单（每天重置勾选，累计天数/分钟；自成一体，不进 .canvas）
 DIARY_DIR = DATA / "diary"   # 起步页「日历」日记：每天一份 Markdown，与学习/速记数据解耦
 CALENDAR_PINS_FILE = DATA / "calendar-pins.json"   # 日历月历上的任务便签（按月份保存自由坐标）
@@ -154,6 +155,8 @@ LARGE_JSON_BODY_BYTES = 8 * 1024 * 1024
 FILE_STREAM_CHUNK_BYTES = 256 * 1024
 VIEWPORT_STATE_LIMIT = 500
 CANVAS_STATS_CACHE_LIMIT = 512
+CANVAS_ACTIVITY_SCHEMA = 1
+CANVAS_ACTIVITY_HEARTBEAT_MAX_SEC = 10 * 60
 # 画布伴生素材统一可被 /api/canvas-asset 读取的类型（图片 + 附件）。
 CANVAS_ASSET_TYPES = {**BACKGROUND_IMAGE_TYPES, **CANVAS_ATTACHMENT_TYPES}
 
@@ -308,6 +311,7 @@ def move_canvas_to_trash(src: Path) -> Path:
             index += 1
     move_canvas_with_assets(src, dst)
     move_viewport_state(src, dst)
+    move_canvas_activity_path(src, dst)
     remove_from_recent(src)
     return dst
 
@@ -3447,6 +3451,526 @@ def study_public_payload() -> dict:
     return data
 
 
+def _empty_canvas_activity() -> dict:
+    return {
+        "version": CANVAS_ACTIVITY_SCHEMA,
+        "backfillVersion": 0,
+        "canvases": {},
+        "paths": {},
+        "days": {},
+    }
+
+
+def _canvas_activity_path_key(path: Path | str) -> str:
+    return os.path.normcase(_norm(path))
+
+
+def _normalize_canvas_activity(raw: object) -> dict:
+    source = raw if isinstance(raw, dict) else {}
+    payload = _empty_canvas_activity()
+    try:
+        payload["backfillVersion"] = max(0, int(source.get("backfillVersion") or 0))
+    except (TypeError, ValueError):
+        pass
+    canvases = source.get("canvases")
+    if isinstance(canvases, dict):
+        for canvas_id, item in canvases.items():
+            if not isinstance(item, dict):
+                continue
+            cid = str(canvas_id or "").strip()
+            path = str(item.get("path") or "").strip()
+            if not cid or not path:
+                continue
+            aliases = item.get("aliases") if isinstance(item.get("aliases"), list) else []
+            clean = {
+                "path": path,
+                "title": str(item.get("title") or Path(path).stem or "Untitled")[:240],
+                "aliases": list(dict.fromkeys(
+                    str(alias) for alias in aliases if str(alias or "").strip()
+                ))[-24:],
+                "firstSeenAt": str(item.get("firstSeenAt") or ""),
+                "lastSeenAt": str(item.get("lastSeenAt") or ""),
+                "backfilled": bool(item.get("backfilled")),
+            }
+            payload["canvases"][cid] = clean
+            payload["paths"][_canvas_activity_path_key(path)] = cid
+    days = source.get("days")
+    if isinstance(days, dict):
+        for day, entries in days.items():
+            day_key = str(day or "")
+            try:
+                date.fromisoformat(day_key)
+            except ValueError:
+                continue
+            if not isinstance(entries, dict):
+                continue
+            clean_entries = {}
+            for canvas_id, item in entries.items():
+                cid = str(canvas_id or "").strip()
+                if not cid or not isinstance(item, dict):
+                    continue
+                spans = []
+                for span in item.get("spans", []):
+                    if not isinstance(span, list) or len(span) != 2:
+                        continue
+                    try:
+                        start = max(0.0, min(86400.0, float(span[0])))
+                        end = max(start, min(86400.0, float(span[1])))
+                    except (TypeError, ValueError):
+                        continue
+                    if end > start:
+                        spans.append([start, end])
+                merged = _merge_canvas_activity_spans(spans)
+                clean_entries[cid] = {
+                    "spans": merged,
+                    "seconds": int(round(sum(end - start for start, end in merged))),
+                    "created": bool(item.get("created")),
+                    "modified": bool(item.get("modified")),
+                    "inferred": bool(item.get("inferred")),
+                }
+            if clean_entries:
+                payload["days"][day_key] = clean_entries
+    return payload
+
+
+def _load_canvas_activity_unlocked() -> dict:
+    if not CANVAS_ACTIVITY_FILE.is_file():
+        return _empty_canvas_activity()
+    try:
+        raw = json.loads(CANVAS_ACTIVITY_FILE.read_text(encoding="utf-8-sig"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return _empty_canvas_activity()
+    return _normalize_canvas_activity(raw)
+
+
+def _save_canvas_activity_unlocked(data: dict) -> None:
+    data["version"] = CANVAS_ACTIVITY_SCHEMA
+    _atomic_write_json(CANVAS_ACTIVITY_FILE, data)
+
+
+def _merge_canvas_activity_spans(spans: list[list[float]]) -> list[list[float]]:
+    ordered = sorted(
+        ([float(span[0]), float(span[1])] for span in spans if span[1] > span[0]),
+        key=lambda span: span[0],
+    )
+    merged: list[list[float]] = []
+    for start, end in ordered:
+        if merged and start <= merged[-1][1] + 0.25:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+    return [[round(start, 3), round(end, 3)] for start, end in merged]
+
+
+def _canvas_activity_recent_id(path: Path | str) -> str:
+    key = _canvas_activity_path_key(path)
+    recent = load_recent()
+    for item in recent.get("files", []):
+        if _canvas_activity_path_key(item.get("path", "")) == key:
+            value = str(item.get("id") or "").strip()
+            if value:
+                return value
+    return uuid.uuid4().hex
+
+
+def _ensure_canvas_activity_identity(
+    data: dict,
+    path: Path | str,
+    *,
+    title: str | None = None,
+) -> tuple[str, dict, bool]:
+    normalized = _norm(path)
+    key = _canvas_activity_path_key(normalized)
+    canvas_id = str(data.get("paths", {}).get(key) or "")
+    changed = False
+    if canvas_id not in data.get("canvases", {}):
+        canvas_id = _canvas_activity_recent_id(normalized)
+        while canvas_id in data.get("canvases", {}):
+            canvas_id = uuid.uuid4().hex
+        now = _study_now()
+        data.setdefault("canvases", {})[canvas_id] = {
+            "path": normalized,
+            "title": str(title or Path(normalized).stem or "Untitled")[:240],
+            "aliases": [],
+            "firstSeenAt": now,
+            "lastSeenAt": now,
+            "backfilled": False,
+        }
+        data.setdefault("paths", {})[key] = canvas_id
+        changed = True
+    meta = data["canvases"][canvas_id]
+    if meta.get("path") != normalized:
+        previous = str(meta.get("path") or "")
+        aliases = list(meta.get("aliases") or [])
+        if previous and previous not in aliases:
+            aliases.append(previous)
+        meta["aliases"] = aliases[-24:]
+        meta["path"] = normalized
+        if previous:
+            data.setdefault("paths", {}).pop(_canvas_activity_path_key(previous), None)
+        data.setdefault("paths", {})[key] = canvas_id
+        changed = True
+    next_title = str(title or Path(normalized).stem or meta.get("title") or "Untitled")[:240]
+    if meta.get("title") != next_title:
+        meta["title"] = next_title
+        changed = True
+    meta["lastSeenAt"] = _study_now()
+    return canvas_id, meta, changed
+
+
+def _canvas_activity_day_entry(data: dict, day: str, canvas_id: str) -> dict:
+    entries = data.setdefault("days", {}).setdefault(day, {})
+    return entries.setdefault(canvas_id, {
+        "spans": [], "seconds": 0, "created": False, "modified": False, "inferred": False,
+    })
+
+
+def _canvas_activity_file_times(path: Path, payload: dict | None = None) -> tuple[str, str]:
+    content = payload if isinstance(payload, dict) else None
+    if content is None:
+        try:
+            content = json.loads(path.read_text(encoding="utf-8-sig"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            content = {}
+    try:
+        stat = path.stat()
+    except OSError:
+        stat = None
+    created = str(content.get("createdAt") or "").strip()
+    updated = str(content.get("updatedAt") or "").strip()
+    if not created and stat is not None:
+        created = datetime.fromtimestamp(getattr(stat, "st_birthtime", stat.st_ctime)).isoformat()
+    if not updated and stat is not None:
+        updated = datetime.fromtimestamp(stat.st_mtime).isoformat()
+    return created, updated
+
+
+def _canvas_activity_day(value: object) -> str:
+    raw = str(value or "").strip()[:10]
+    try:
+        return date.fromisoformat(raw).isoformat()
+    except ValueError:
+        return ""
+
+
+def _backfill_canvas_activity_file_unlocked(
+    data: dict,
+    path: Path,
+    *,
+    payload: dict | None = None,
+) -> tuple[str, bool]:
+    canvas_id, meta, changed = _ensure_canvas_activity_identity(data, path, title=path.stem)
+    if meta.get("backfilled"):
+        return canvas_id, changed
+    created_at, updated_at = _canvas_activity_file_times(path, payload)
+    created_day = _canvas_activity_day(created_at)
+    updated_day = _canvas_activity_day(updated_at)
+    if created_day:
+        entry = _canvas_activity_day_entry(data, created_day, canvas_id)
+        entry["created"] = True
+        entry["inferred"] = True
+    if updated_day:
+        entry = _canvas_activity_day_entry(data, updated_day, canvas_id)
+        entry["modified"] = True
+        entry["inferred"] = True
+    meta["backfilled"] = True
+    return canvas_id, True
+
+
+def _canvas_activity_backfill_all_unlocked(data: dict) -> bool:
+    if int(data.get("backfillVersion") or 0) >= CANVAS_ACTIVITY_SCHEMA:
+        return False
+    candidates: dict[str, Path] = {}
+    if CANVASES.exists():
+        for path in CANVASES.glob("*.canvas"):
+            if path.is_file():
+                candidates[_canvas_activity_path_key(path)] = path
+    for raw in recent_paths():
+        path = Path(raw)
+        if path.is_file() and is_authorized(path) and not is_in_trash(path):
+            candidates[_canvas_activity_path_key(path)] = path
+    for path in candidates.values():
+        _backfill_canvas_activity_file_unlocked(data, path)
+    data["backfillVersion"] = CANVAS_ACTIVITY_SCHEMA
+    return True
+
+
+@_serialized_data
+def canvas_activity_register_path(path: Path, payload: dict | None = None) -> dict:
+    data = _load_canvas_activity_unlocked()
+    changed = _canvas_activity_backfill_all_unlocked(data)
+    canvas_id, file_changed = _backfill_canvas_activity_file_unlocked(data, path, payload=payload)
+    changed = changed or file_changed
+    if changed:
+        _save_canvas_activity_unlocked(data)
+    return _canvas_activity_totals(data, canvas_id)
+
+
+@_serialized_data
+def record_canvas_activity_event(
+    path: Path,
+    event: str,
+    *,
+    when: str | None = None,
+    payload: dict | None = None,
+) -> dict:
+    data = _load_canvas_activity_unlocked()
+    canvas_id, meta, _ = _ensure_canvas_activity_identity(data, path, title=path.stem)
+    meta["backfilled"] = True
+    day = _canvas_activity_day(when or _study_now())
+    entry = _canvas_activity_day_entry(data, day, canvas_id)
+    if event == "created":
+        entry["created"] = True
+    elif event == "modified":
+        entry["modified"] = True
+    else:
+        raise ValueError("未知画布活动类型")
+    entry["inferred"] = False
+    _save_canvas_activity_unlocked(data)
+    return _canvas_activity_totals(data, canvas_id)
+
+
+@_serialized_data
+def move_canvas_activity_path(src: Path | str, dst: Path | str) -> None:
+    data = _load_canvas_activity_unlocked()
+    source_key = _canvas_activity_path_key(src)
+    canvas_id = str(data.get("paths", {}).get(source_key) or "")
+    if canvas_id not in data.get("canvases", {}):
+        return
+    meta = data["canvases"][canvas_id]
+    old_path = str(meta.get("path") or _norm(src))
+    aliases = list(meta.get("aliases") or [])
+    if old_path and old_path not in aliases:
+        aliases.append(old_path)
+    meta["aliases"] = aliases[-24:]
+    meta["path"] = _norm(dst)
+    meta["title"] = Path(dst).stem
+    meta["lastSeenAt"] = _study_now()
+    data.setdefault("paths", {}).pop(source_key, None)
+    data["paths"][_canvas_activity_path_key(dst)] = canvas_id
+    _save_canvas_activity_unlocked(data)
+
+
+def _parse_canvas_activity_time(value: object) -> datetime:
+    raw = str(value or "").strip()
+    if not raw:
+        raise ValueError("缺少计时起止时间")
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as err:
+        raise ValueError("计时时间格式不正确") from err
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone().replace(tzinfo=None)
+    return parsed
+
+
+def _split_canvas_activity_interval(start: datetime, end: datetime) -> list[tuple[str, float, float]]:
+    parts = []
+    cursor = start
+    while cursor < end:
+        midnight = datetime.combine(cursor.date() + timedelta(days=1), datetime.min.time())
+        part_end = min(end, midnight)
+        day_start = datetime.combine(cursor.date(), datetime.min.time())
+        parts.append((
+            cursor.date().isoformat(),
+            (cursor - day_start).total_seconds(),
+            (part_end - day_start).total_seconds(),
+        ))
+        cursor = part_end
+    return parts
+
+
+def _canvas_activity_totals(data: dict, canvas_id: str) -> dict:
+    today = date.today().isoformat()
+    total = 0
+    today_total = 0
+    for day, entries in data.get("days", {}).items():
+        entry = entries.get(canvas_id) if isinstance(entries, dict) else None
+        if not isinstance(entry, dict):
+            continue
+        seconds = max(0, int(entry.get("seconds") or 0))
+        total += seconds
+        if day == today:
+            today_total = seconds
+    return {"canvasId": canvas_id, "todaySec": today_total, "totalSec": total}
+
+
+def _canvas_activity_total_seconds_by_id(data: dict) -> dict[str, int]:
+    totals: dict[str, int] = {}
+    for entries in data.get("days", {}).values():
+        if not isinstance(entries, dict):
+            continue
+        for canvas_id, entry in entries.items():
+            if isinstance(entry, dict):
+                totals[canvas_id] = totals.get(canvas_id, 0) + max(0, int(entry.get("seconds") or 0))
+    return totals
+
+
+@_serialized_data
+def record_canvas_activity_interval(body: dict) -> dict:
+    path = Path(str(body.get("path") or "").strip())
+    if not str(path) or not path.is_file():
+        raise FileNotFoundError("画布文件不存在")
+    if path.suffix.lower() != ".canvas":
+        raise ValueError("计时目标不是 .canvas 文件")
+    if not is_authorized(path):
+        raise PermissionError("画布路径未授权")
+    session_id = str(body.get("sessionId") or "").strip()
+    if not session_id or len(session_id) > 160:
+        raise ValueError("计时会话标识无效")
+    start = _parse_canvas_activity_time(body.get("startedAt"))
+    end = _parse_canvas_activity_time(body.get("endedAt"))
+    duration = (end - start).total_seconds()
+    if duration <= 0 or duration > CANVAS_ACTIVITY_HEARTBEAT_MAX_SEC:
+        raise ValueError("计时时段长度无效")
+    if end > datetime.now() + timedelta(minutes=2):
+        raise ValueError("计时时段不能位于未来")
+    data = _load_canvas_activity_unlocked()
+    canvas_id, meta, _ = _ensure_canvas_activity_identity(data, path, title=path.stem)
+    if not meta.get("backfilled"):
+        _backfill_canvas_activity_file_unlocked(data, path)
+    for day, start_sec, end_sec in _split_canvas_activity_interval(start, end):
+        entry = _canvas_activity_day_entry(data, day, canvas_id)
+        entry["spans"] = _merge_canvas_activity_spans(
+            list(entry.get("spans") or []) + [[start_sec, end_sec]]
+        )
+        entry["seconds"] = int(round(sum(b - a for a, b in entry["spans"])))
+    _save_canvas_activity_unlocked(data)
+    return _canvas_activity_totals(data, canvas_id)
+
+
+@_serialized_data
+def canvas_activity_snapshot() -> dict:
+    data = _load_canvas_activity_unlocked()
+    changed = _canvas_activity_backfill_all_unlocked(data)
+    if changed:
+        _save_canvas_activity_unlocked(data)
+    return data
+
+
+def _canvas_activity_payload(data: dict, year: int) -> dict:
+    prefix = f"{year:04d}-"
+    canvases = data.get("canvases", {})
+    all_totals = _canvas_activity_total_seconds_by_id(data)
+
+    days_payload: dict[str, dict] = {}
+    entry_payload: list[dict] = []
+    active_ids: set[str] = set()
+    created_count = 0
+    month_buckets: dict[str, dict[str, dict]] = {}
+    for day in sorted(data.get("days", {})):
+        if not day.startswith(prefix):
+            continue
+        entries = data["days"].get(day)
+        if not isinstance(entries, dict):
+            continue
+        day_sec = 0
+        day_created = 0
+        day_modified = 0
+        day_inferred = False
+        day_ids: set[str] = set()
+        for canvas_id, entry in entries.items():
+            if not isinstance(entry, dict):
+                continue
+            seconds = max(0, int(entry.get("seconds") or 0))
+            created = bool(entry.get("created"))
+            modified = bool(entry.get("modified"))
+            inferred = bool(entry.get("inferred")) and not seconds
+            if not seconds and not created and not modified:
+                continue
+            meta = canvases.get(canvas_id, {}) if isinstance(canvases.get(canvas_id), dict) else {}
+            path = str(meta.get("path") or "")
+            title = str(meta.get("title") or (Path(path).stem if path else "Untitled"))
+            available = bool(path and Path(path).is_file() and is_authorized(Path(path)) and not is_in_trash(Path(path)))
+            item = {
+                "id": canvas_id,
+                "day": day,
+                "title": title,
+                "path": path,
+                "canvasAvailable": available,
+                "durationSec": seconds,
+                "totalDurationSec": all_totals.get(canvas_id, 0),
+                "created": created,
+                "modified": modified,
+                "inferred": inferred,
+            }
+            entry_payload.append(item)
+            day_sec += seconds
+            day_created += int(created)
+            day_modified += int(modified)
+            day_inferred = day_inferred or inferred
+            day_ids.add(canvas_id)
+            active_ids.add(canvas_id)
+            created_count += int(created)
+            month = day[:7]
+            bucket = month_buckets.setdefault(month, {})
+            canvas_bucket = bucket.setdefault(canvas_id, {
+                "id": canvas_id, "title": title, "durationSec": 0,
+                "totalDurationSec": all_totals.get(canvas_id, 0),
+                "day": day, "path": path, "canvasAvailable": available, "inferred": False,
+            })
+            canvas_bucket["durationSec"] += seconds
+            canvas_bucket["day"] = max(str(canvas_bucket.get("day") or ""), day)
+            canvas_bucket["inferred"] = bool(canvas_bucket.get("inferred")) or inferred
+        if day_ids:
+            days_payload[day] = {
+                "durationSec": day_sec,
+                "canvasCount": len(day_ids),
+                "createdCount": day_created,
+                "modifiedCount": day_modified,
+                "inferred": day_inferred and day_sec == 0,
+            }
+
+    entry_payload.sort(key=lambda item: (item["day"], item["durationSec"], item["title"]), reverse=True)
+    graph_months = []
+    for month in sorted(month_buckets):
+        items = list(month_buckets[month].values())
+        graph_months.append({
+            "month": month,
+            "total": len(items),
+            "durationSec": sum(item["durationSec"] for item in items),
+            "named": sorted(items, key=lambda item: (item["durationSec"], item["title"]), reverse=True),
+            "unnamed": 0,
+        })
+
+    active_days = {day: 1 for day, item in days_payload.items() if item["durationSec"] or item["inferred"] or item["createdCount"] or item["modifiedCount"]}
+    today = date.today()
+    cursor = today if active_days.get(today.isoformat()) else today - timedelta(days=1)
+    streak = 0
+    while active_days.get(cursor.isoformat()):
+        streak += 1
+        cursor -= timedelta(days=1)
+    month_key = today.strftime("%Y-%m")
+    return {
+        "days": days_payload,
+        "entries": entry_payload,
+        "stats": {
+            "monthSec": sum(item["durationSec"] for day, item in days_payload.items() if day.startswith(month_key)),
+            "yearSec": sum(item["durationSec"] for item in days_payload.values()),
+            "totalSec": sum(all_totals.values()),
+            "streak": streak,
+            "longestStreak": _study_longest_streak(active_days),
+            "activeCanvasCount": len(active_ids),
+            "createdCount": created_count,
+        },
+        "graph": {"kind": "canvas", "months": graph_months},
+    }
+
+
+def _canvas_activity_overview_graph(data: dict) -> dict:
+    years = sorted({day[:4] for day in data.get("days", {}) if day[:4].isdigit()}, reverse=True)
+    result = []
+    for raw_year in years:
+        payload = _canvas_activity_payload(data, int(raw_year))
+        result.append({
+            "year": raw_year,
+            "total": payload["stats"]["activeCanvasCount"],
+            "durationSec": payload["stats"]["yearSec"],
+            "months": payload["graph"]["months"],
+        })
+    return {"kind": "canvas", "years": result}
+
+
 def study_activity_records() -> tuple[dict[str, int], list[dict]]:
     """按归档日期汇总学习任务、速记、画布节点和任务簿完成记录。
 
@@ -3848,6 +4372,7 @@ def _study_longest_streak(days: dict[str, int]) -> int:
 def study_activity_payload(selected_year: str | int | None = None) -> dict:
     days, records = study_activity_records()
     focus_days_all = load_focus()["days"]
+    canvas_activity = canvas_activity_snapshot()
     today = date.today()
     archive_years = {
         int(day[:4]) for day in days
@@ -3857,7 +4382,11 @@ def study_activity_payload(selected_year: str | int | None = None) -> dict:
         int(day[:4]) for day in focus_days_all
         if len(day) >= 4 and day[:4].isdigit()
     }
-    years = sorted(archive_years | focus_years | {today.year}, reverse=True)
+    canvas_years = {
+        int(day[:4]) for day in canvas_activity.get("days", {})
+        if len(day) >= 4 and day[:4].isdigit()
+    }
+    years = sorted(archive_years | focus_years | canvas_years | {today.year}, reverse=True)
     try:
         year = int(selected_year) if selected_year is not None else today.year
     except (TypeError, ValueError):
@@ -3918,6 +4447,7 @@ def study_activity_payload(selected_year: str | int | None = None) -> dict:
 
     # 专注时间层（与归档解耦，直接读 focus.json 的每日汇总）：当年逐日 + 今日/本月/今年/累计。
     focus_year = {day: val for day, val in focus_days_all.items() if day.startswith(year_prefix)}
+    canvas_year = _canvas_activity_payload(canvas_activity, year)
 
     return {
         "year": year,
@@ -3936,6 +4466,11 @@ def study_activity_payload(selected_year: str | int | None = None) -> dict:
         "entries": year_records,
         "graph": graph,
         "overviewGraph": overview_graph,
+        "canvasDays": canvas_year["days"],
+        "canvasEntries": canvas_year["entries"],
+        "canvasStats": canvas_year["stats"],
+        "canvasGraph": canvas_year["graph"],
+        "canvasOverviewGraph": _canvas_activity_overview_graph(canvas_activity),
         "focusDays": focus_year,
         "focusStats": {
             "today": focus_days_all.get(today.isoformat(), {}).get("sec", 0),
@@ -5748,6 +6283,7 @@ def import_markdown_folder(source: Path) -> tuple[Path, int, int]:
     except OSError as err:
         raise OSError(f"创建导入画布失败：{err}") from err
     register_recent(target)
+    record_canvas_activity_event(target, "created", payload=payload)
     return target, len(nodes), len(edges)
 
 
@@ -5979,12 +6515,8 @@ POST_WITHOUT_DATA_LOCK = {
 # study/calendar/daily JSON updates. Routes that touch both domains always take
 # the canvas lock first to keep one lock order throughout the process.
 CANVAS_FILE_POST_ROUTES = {
-    "/api/new",
-    "/api/save",
     "/api/clean-assets",
-    "/api/trash",
     "/api/trash-empty",
-    "/api/import-canvas",
     "/api/canvas-import-assets",
     "/api/upload-background-image",
     "/api/upload-canvas-image",
@@ -5994,6 +6526,10 @@ CANVAS_FILE_POST_ROUTES = {
     "/api/archive-canvas",
 }
 CANVAS_AND_DATA_POST_ROUTES = {
+    "/api/new",
+    "/api/save",
+    "/api/trash",
+    "/api/import-canvas",
     "/api/study-archive-done",
     "/api/study-task-create-canvas",
     "/api/taskbook-archive",
@@ -6319,6 +6855,8 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             return self._api_study_trash_empty()
         if path == "/api/study-archive-done":
             return self._api_study_archive_done()
+        if path == "/api/canvas-activity":
+            return self._api_canvas_activity(body)
         if path == "/api/archive-canvas":
             return self._api_archive_canvas(body)
         if path == "/api/taskbook-archive":
@@ -6492,6 +7030,16 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     # ── API 实现 ──
     def _api_recent(self):
         data = load_recent()
+        activity = canvas_activity_snapshot()
+        totals = _canvas_activity_total_seconds_by_id(activity)
+        activity_paths = activity.get("paths", {})
+        for item in data.get("files", []):
+            if not isinstance(item, dict):
+                continue
+            canvas_id = str(item.get("id") or "")
+            if canvas_id not in totals:
+                canvas_id = str(activity_paths.get(_canvas_activity_path_key(item.get("path", ""))) or "")
+            item["canvasActivitySec"] = totals.get(canvas_id, 0)
         data["recentLimit"] = RECENT_LIMIT
         self._send_json(200, data)
 
@@ -6506,16 +7054,32 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             )
         self._send_json(200, {"files": recent_file_stats(paths)})
 
+    def _api_canvas_activity(self, body: dict):
+        try:
+            totals = record_canvas_activity_interval(body if isinstance(body, dict) else {})
+        except FileNotFoundError as err:
+            return self._send_json(404, {"error": str(err)})
+        except PermissionError as err:
+            return self._send_json(403, {"error": str(err)})
+        except ValueError as err:
+            return self._send_json(400, {"error": str(err)})
+        except OSError as err:
+            return self._send_json(500, {"error": f"保存画布时间失败：{err}"})
+        self._send_json(200, {"ok": True, **totals})
+
     def _api_new(self):
         target = make_new_canvas_path()
+        payload = empty_canvas_payload()
         try:
-            _atomic_write_json(target, empty_canvas_payload())
+            _atomic_write_json(target, payload)
         except OSError as err:
             return self._send_json(500, {"error": f"创建失败：{err}"})
         register_recent(target)
+        activity = record_canvas_activity_event(target, "created", payload=payload)
         self._send_json(200, {
             "path": _norm(target),
             "title": target.stem,
+            "canvasActivity": activity,
         })
 
     def _api_import_canvas(self, body: dict):
@@ -6551,6 +7115,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         except OSError as err:
             return self._send_json(500, {"error": f"导入失败：{err}"})
         register_recent(target, target.stem)
+        activity = record_canvas_activity_event(target, "created", payload=parsed)
         gid = str(body.get("group") or "")
         if gid:
             file_set_group(_norm(target), gid)
@@ -6563,6 +7128,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             "title": target.stem,
             "group": gid,
             "hasAssets": has_assets,
+            "canvasActivity": activity,
         })
 
     def _api_canvas_import_assets(self, body: dict):
@@ -7476,15 +8042,20 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             return self._send_json(404, {"error": str(err)})
         title = _safe_export_stem(task.get("title"), "未命名任务")
         target = _unused_canvas_path(CANVASES, title)
+        payload = empty_canvas_payload()
         try:
-            _atomic_write_json(target, empty_canvas_payload())
+            _atomic_write_json(target, payload)
         except OSError as err:
             return self._send_json(500, {"error": f"创建画布失败：{err}"})
         register_recent(target)
+        activity = record_canvas_activity_event(target, "created", payload=payload)
         task = _study_task({"linkedCanvas": _norm(target)}, existing=task)
         data["tasks"][index] = task
         save_study(data)
-        self._send_json(200, {"task": task, "path": _norm(target), "title": target.stem})
+        self._send_json(200, {
+            "task": task, "path": _norm(target), "title": target.stem,
+            "canvasActivity": activity,
+        })
 
     def _api_open(self, body: dict):
         raw = (body.get("path") or "").strip()
@@ -7527,11 +8098,16 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         # 回收站页允许打开已删除画布查看，但不能因此重新混入“最近”。
         if not is_in_trash(target):
             register_recent(target)
+        try:
+            activity = canvas_activity_register_path(target, data)
+        except OSError:
+            activity = {"canvasId": "", "todaySec": 0, "totalSec": 0}
         self._send_json(200, {
             "path": _norm(target),
             "title": target.stem,
             "data": data,
             "viewport": load_viewport_state(target),
+            "canvasActivity": activity,
         })
 
     def _api_save(self, body: dict):
@@ -7551,6 +8127,10 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             )
         except OSError as err:
             return self._send_json(500, {"error": f"写入失败：{err}"})
+        try:
+            activity = record_canvas_activity_event(target, "modified", payload=payload)
+        except OSError:
+            activity = {"canvasId": "", "todaySec": 0, "totalSec": 0}
         orphan_count = 0
         orphan_annotation_count = 0
         try:
@@ -7581,6 +8161,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             "savedAt": payload["updatedAt"],
             "orphanCount": orphan_count,
             "orphanAnnotationCount": orphan_annotation_count,
+            "canvasActivity": activity,
         })
 
     def _api_clean_assets(self, body: dict):
@@ -7699,6 +8280,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         rename_in_recent(src, dst)
         move_viewport_state(src, dst)
         rewrite_taskbook_focus_canvas_path(src, dst)
+        move_canvas_activity_path(src, dst)
         self._send_json(200, {"path": _norm(dst), "title": dst.stem})
 
     # ── 分组（阶段 3a）──
@@ -7916,6 +8498,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             return self._send_json(500, {"error": f"恢复失败：{err}"})
         move_viewport_state(src, dst)
         rewrite_taskbook_focus_canvas_path(src, dst)
+        move_canvas_activity_path(src, dst)
         register_recent(dst)
         if gid:
             file_set_group(_norm(dst), gid)   # 目标组不存在则忽略（留在未分组）

--- a/assets/editor.js
+++ b/assets/editor.js
@@ -9088,6 +9088,109 @@
   let pendingViewport = null;
   let viewportSaveQueue = Promise.resolve();
   let graphView = null;
+  let canvasActivityReady = false;
+  let canvasActivityActive = false;
+  let canvasActivityLastCapturedAt = 0;
+  let canvasActivityHeartbeat = 0;
+  let canvasActivitySending = null;
+  const canvasActivityPending = [];
+  const canvasActivitySessionId = (window.crypto && typeof window.crypto.randomUUID === 'function')
+    ? window.crypto.randomUUID()
+    : 'canvas-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
+
+  function captureCanvasActivity(endAt) {
+    if (!canvasActivityActive || !canvasActivityLastCapturedAt) return;
+    const endedAt = Math.max(canvasActivityLastCapturedAt, Number(endAt) || Date.now());
+    let cursor = canvasActivityLastCapturedAt;
+    while (endedAt - cursor >= 250) {
+      const chunkEnd = Math.min(endedAt, cursor + 9 * 60 * 1000);
+      canvasActivityPending.push({ startedAt: cursor, endedAt: chunkEnd });
+      cursor = chunkEnd;
+    }
+    canvasActivityLastCapturedAt = endedAt;
+  }
+
+  function sendNextCanvasActivity(keepalive) {
+    if (canvasActivitySending || !canvasActivityPending.length || !filePath) return;
+    const interval = canvasActivityPending[0];
+    canvasActivitySending = interval;
+    postCanvasActivity(interval, keepalive)
+      .then(({ response, json }) => {
+        if (!response.ok) throw new Error(json.error || 'canvas activity failed');
+        const index = canvasActivityPending.indexOf(interval);
+        if (index >= 0) canvasActivityPending.splice(index, 1);
+      })
+      .catch((error) => {
+        console.warn('[画布] 前台时间暂未写入，将稍后重试', error);
+      })
+      .finally(() => {
+        if (canvasActivitySending === interval) canvasActivitySending = null;
+        if (canvasActivityPending.length && canvasActivityActive) {
+          window.setTimeout(() => sendNextCanvasActivity(false), 1200);
+        }
+      });
+  }
+
+  function postCanvasActivity(interval, keepalive) {
+    return fetch('/api/canvas-activity', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      keepalive: !!keepalive,
+      body: JSON.stringify({
+        path: filePath,
+        sessionId: canvasActivitySessionId,
+        startedAt: new Date(interval.startedAt).toISOString(),
+        endedAt: new Date(interval.endedAt).toISOString(),
+      }),
+    }).then((response) => response.json().then((json) => ({ response, json })));
+  }
+
+  function flushCanvasActivityKeepalive() {
+    canvasActivityPending.slice().forEach((interval) => {
+      postCanvasActivity(interval, true)
+      .then(({ response, json }) => {
+        if (!response.ok) throw new Error(json.error || 'canvas activity failed');
+        const index = canvasActivityPending.indexOf(interval);
+        if (index >= 0) canvasActivityPending.splice(index, 1);
+      })
+      .catch(() => {});
+    });
+  }
+
+  function pauseCanvasActivity(keepalive) {
+    if (!canvasActivityActive) return;
+    captureCanvasActivity(Date.now());
+    canvasActivityActive = false;
+    canvasActivityLastCapturedAt = 0;
+    if (canvasActivityHeartbeat) window.clearInterval(canvasActivityHeartbeat);
+    canvasActivityHeartbeat = 0;
+    if (keepalive) flushCanvasActivityKeepalive();
+    else sendNextCanvasActivity(false);
+  }
+
+  function resumeCanvasActivity() {
+    if (!canvasActivityReady || canvasActivityActive || document.hidden || !document.hasFocus()) return;
+    canvasActivityActive = true;
+    canvasActivityLastCapturedAt = Date.now();
+    if (canvasActivityHeartbeat) window.clearInterval(canvasActivityHeartbeat);
+    canvasActivityHeartbeat = window.setInterval(() => {
+      captureCanvasActivity(Date.now());
+      sendNextCanvasActivity(false);
+    }, 30000);
+    sendNextCanvasActivity(false);
+  }
+
+  function startCanvasActivityTracker() {
+    canvasActivityReady = true;
+    window.addEventListener('focus', resumeCanvasActivity);
+    window.addEventListener('blur', () => pauseCanvasActivity(true));
+    window.addEventListener('pagehide', () => pauseCanvasActivity(true));
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) pauseCanvasActivity(true);
+      else resumeCanvasActivity();
+    });
+    window.requestAnimationFrame(resumeCanvasActivity);
+  }
 
   const BACKGROUND_GRADIENTS = {
     'morning-mist': {
@@ -10278,6 +10381,7 @@
           onChange: markDirty,
         });
         document.dispatchEvent(new CustomEvent('editor:canvasready'));
+        startCanvasActivityTracker(json.canvasActivity || {});
         if ((LOCATE_NODE || LOCATE_TASK_ROOT) && typeof window.CanvasModule.revealNode === 'function') {
           window.setTimeout(() => {
             let located = false;
@@ -10412,6 +10516,7 @@
       });
       const json = await resp.json();
       if (resp.ok) {
+        applyCanvasActivityTotals(json.canvasActivity || {});
         if (dirtyEpoch === savedEpoch) {
           markClean('已保存');             // 保存途中没有新编辑 → 确实干净
         } else {

--- a/assets/focus.js
+++ b/assets/focus.js
@@ -17,6 +17,8 @@
   const TASK_KEY = 'canvas:focusTask';
   const KIND_KEY = 'canvas:focusTaskKind';
   const STATE_KEY = 'canvas:focusRuntime';
+  const VIEW_MODE_KEY = 'focus:viewMode';
+  const DAILY_REVIEWED_KEY = 'focus:dailyReviewedDate';
   const RUNTIME_PERSIST_MS = 5000;
   const DUR_DEFAULT = { focus: 25, brk: 5, long: 15, rounds: 4 };
   const LOG_MIN_SEC = 60;
@@ -27,6 +29,8 @@
     try { return window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (e) { return false; }
   })();
   const T = (window.RelatumI18n && window.RelatumI18n.t) || function (s) { return s; };
+  const bootFocusData = window.RelatumBoot && window.RelatumBoot.focus
+    ? window.RelatumBoot.focus : {};
 
   const ringWrap = root.querySelector('[data-role="focus-ring-wrap"]');
   const ringFill = root.querySelector('[data-role="focus-ring-fill"]');
@@ -74,14 +78,22 @@
   const sessionGoalEl = root.querySelector('[data-role="focus-session-goal"]');
   const sessionOutcomeEl = root.querySelector('[data-role="focus-session-outcome"]');
   const sessionSourceEl = root.querySelector('[data-role="focus-session-source"]');
+  const timerViewEl = root.querySelector('[data-role="focus-timer-view"]');
   const dailyRoot = root.querySelector('[data-role="focus-daily"]');
-  const dailyHandle = root.querySelector('.focus-daily-handle');
+  const dailyScrollEl = root.querySelector('[data-role="focus-daily-scroll"]');
+  const dailyCountEl = root.querySelector('[data-role="focus-daily-count"]');
+  const dailyCreateBtn = root.querySelector('[data-action="daily-compose-toggle"]');
+  const dailySkeletonEl = root.querySelector('[data-role="focus-daily-skeleton"]');
+  const dailyComposerEl = root.querySelector('[data-role="focus-daily-composer"]');
   const dailyListEl = root.querySelector('[data-role="focus-daily-list"]');
   const dailyAddForm = root.querySelector('[data-role="focus-daily-add"]');
   const dailyInputEl = root.querySelector('[data-role="focus-daily-input"]');
+  const dailySubmitBtn = dailyAddForm && dailyAddForm.querySelector('button[type="submit"]');
   const dailyFootEl = root.querySelector('[data-role="focus-daily-foot"]');
   const dailyCelebrateEl = root.querySelector('[data-role="focus-daily-celebrate"]');
+  const dailyCelebrateTitleEl = dailyCelebrateEl && dailyCelebrateEl.querySelector('strong');
   const dailyCelebrateSubEl = root.querySelector('[data-role="focus-daily-celebrate-sub"]');
+  const dailyReviewBtn = root.querySelector('[data-action="daily-review-today"]');
   const dailyComposeEl = root.querySelector('[data-role="focus-daily-compose"]');
   const dailyComposeTaskBtn = root.querySelector('[data-role="daily-compose-task"]');
   const dailyComposeGroupBtn = root.querySelector('[data-role="daily-compose-group"]');
@@ -113,7 +125,19 @@
   let dailyTasks = [];
   let dailyGroups = [];           // 分组树：每个 {id,name,parentId,collapsed}，parentId:'' = 根
   let dailyLoaded = false;
-  let dailyOpen = false;
+  let dailySignature = '';
+  let dailyRequestSeq = 0;
+  let dailyRequestController = null;
+  let dailyRevealKey = '';
+  let viewMode = readViewMode();
+  let focusLifecycleActive = false;
+  let focusPrepared = false;
+  let focusActivationSeq = 0;
+  let focusWarmupPromise = null;
+  let viewTransitionSeq = 0;
+  let viewTransitionTimer = 0;
+  let dailyComposerOpen = false;
+  let dailyCreatePending = false;
   let dailyEditId = '';
   let dailyEditMilestones = null;
   let dailyMilestoneDialog = null;
@@ -124,21 +148,26 @@
   let dailyGroupEditId = '';      // 正在展开菜单/改名的分组 id
   let dailyGroupConfirmDeleteId = '';
   const dailyExpandTimers = new WeakMap();  // 分组就地展开的逐项交错收尾计时器，按 wrap 元素索引
-  const dailyHintTimers = new WeakMap();    // 点任务名/空白的「⋯ 提示」收尾计时器，按 row 元素索引
+  const replayCleanupTimers = new WeakMap();
   let dailyComposeMode = 'task';  // 新增控制条当前模式：'task' | 'group'
   let dailyAddTargetGroup = '';   // 新增项的目标父分组；'' = 根
   // 实验开关：隐藏「今日目标」（每日目标分钟）的前端 UI，后端字段与数据保留。
   // 想恢复时改回 false 即可；编辑器输入行与详情页的目标对比会自动还原。
   const DAILY_TARGET_UI_HIDDEN = true;
   let dailyEnterId = '';          // 刚新增的任务/分组 id：仅这一行播放入场动画
-  let dailyPeek = false;          // 全部完成后用户主动「查看清单」，临时展开供取消勾选
   let dailyWasAllDone = false;
-  let dailyClearing = false;      // 清场动画进行中：别让异步刷新打断
-  let dailyClearTimer = 0;
   let dailyDrag = null;
   let dailySuppressClick = false;
   let dailyRevealTimer = 0;
-  let dailyFocusReturnEl = null;
+  let dailyRevealWaitingForData = false;
+  let dailyDataRevealTimer = 0;
+  let dailyCelebrateMotionTimer = 0;
+  let dailyCelebrateHideTimer = 0;
+  let dailyCelebrateGeneration = 0;
+  let dailyCelebratePhase = 'hidden';
+  let dailyCelebrateFocusTimer = 0;
+  let dailyCelebrateReturnId = '';
+  const dailyToggleStates = new Map();
   let dailyHistoryTaskId = '';
   let dailyHistoryMonth = '';
   let dailyDetailTaskId = '';
@@ -244,48 +273,45 @@
     const book = root.closest('.book-view');
     return !!(book && book.classList.contains('focus-active'));
   }
+  function readViewMode() {
+    try { return localStorage.getItem(VIEW_MODE_KEY) === 'daily' ? 'daily' : 'timer'; }
+    catch (e) { return 'timer'; }
+  }
+  function dailyReviewedToday() {
+    const today = todayStr();
+    try {
+      const stored = localStorage.getItem(DAILY_REVIEWED_KEY) || '';
+      if (stored && stored !== today) localStorage.removeItem(DAILY_REVIEWED_KEY);
+      return stored === today;
+    } catch (e) {
+      return false;
+    }
+  }
+  function setDailyReviewedToday(reviewed) {
+    try {
+      if (reviewed) localStorage.setItem(DAILY_REVIEWED_KEY, todayStr());
+      else localStorage.removeItem(DAILY_REVIEWED_KEY);
+    } catch (e) {}
+  }
+  function sessionLocksView() {
+    return !!(running || pendingSession);
+  }
   function isTypingTarget(target) {
     return !!(target && target.closest && target.closest('input, textarea, select, [contenteditable="true"]'));
   }
-  function rememberDailyFocus() {
-    dailyFocusReturnEl = null;
-  }
-  function restoreDailyFocus() {
-    const active = document.activeElement;
-    if (active && dailyRoot && dailyRoot.contains(active) && active.blur) active.blur();
-    if (active && dailyHandle && dailyHandle.contains(active) && active.blur) active.blur();
-    dailyFocusReturnEl = null;
-    if (document.activeElement && document.activeElement !== document.body
-      && document.activeElement !== document.documentElement
-      && !isTypingTarget(document.activeElement)
-      && document.activeElement.blur) document.activeElement.blur();
-  }
-  function settleDailyPanelFocus() {
-    if (!dailyRoot || !dailyOpen) return;
-    const active = document.activeElement;
-    if (active && dailyRoot.contains(active)) return;
-    if (active && active.blur && !isTypingTarget(active)) active.blur();
-  }
-  function syncDailyPanelFocusability() {
-    if (!dailyRoot) return;
-    const enabled = !!dailyOpen;
-    dailyRoot.toggleAttribute('inert', !enabled);
-    dailyRoot.setAttribute('aria-hidden', enabled ? 'false' : 'true');
-    dailyRoot.querySelectorAll(dailyFocusableSelector).forEach((element) => {
-      if (enabled) {
-        if (element.dataset.dailySavedTabindex !== undefined) {
-          const saved = element.dataset.dailySavedTabindex;
-          delete element.dataset.dailySavedTabindex;
-          if (saved === '') element.removeAttribute('tabindex');
-          else element.setAttribute('tabindex', saved);
-        }
-      } else {
-        if (element.dataset.dailySavedTabindex === undefined) {
-          element.dataset.dailySavedTabindex = element.getAttribute('tabindex') || '';
-        }
-        element.setAttribute('tabindex', '-1');
-      }
-    });
+  function syncViewAccessibility(options) {
+    const opts = options || {};
+    const daily = viewMode === 'daily';
+    if (timerViewEl) {
+      timerViewEl.hidden = opts.keepBoth ? false : daily;
+      timerViewEl.toggleAttribute('inert', daily);
+      timerViewEl.setAttribute('aria-hidden', daily ? 'true' : 'false');
+    }
+    if (dailyRoot) {
+      dailyRoot.hidden = opts.keepBoth ? false : !daily;
+      dailyRoot.toggleAttribute('inert', !daily);
+      dailyRoot.setAttribute('aria-hidden', daily ? 'false' : 'true');
+    }
   }
 
   function beginTimeEdit() {
@@ -341,11 +367,21 @@
     }, 2200);
   }
 
-  function replayClass(element, className) {
+  function replayClass(element, className, cleanupMs) {
     if (!element || prefersReduced) return;
+    const cleanupByClass = replayCleanupTimers.get(element) || new Map();
+    window.clearTimeout(cleanupByClass.get(className));
+    cleanupByClass.delete(className);
+    replayCleanupTimers.set(element, cleanupByClass);
     element.classList.remove(className);
     void element.offsetWidth;
     element.classList.add(className);
+    if (Number(cleanupMs) > 0) {
+      cleanupByClass.set(className, window.setTimeout(() => {
+        element.classList.remove(className);
+        cleanupByClass.delete(className);
+      }, Number(cleanupMs)));
+    }
   }
   // 收起浮层/卡片时先播放退场动画，动画结束（或兜底超时）再真正 hidden。
   function dismiss(element, exitClass, after) {
@@ -409,7 +445,16 @@
       replayClass(element, 'focus-stat-updated');
     });
   }
+  function cancelDailyRead() {
+    if (!dailyRequestController) return;
+    dailyRequestSeq += 1;
+    dailyRequestController.abort();
+    dailyRequestController = null;
+  }
   function post(path, body) {
+    // A mutation is newer than any background snapshot requested before it.
+    // Abort that read so a slow GET can never repaint stale task state over the mutation.
+    if (String(path || '').startsWith('/api/daily-')) cancelDailyRead();
     return fetch(path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -1193,8 +1238,24 @@
     });
     if (modeSlider) modeSlider.style.transform = mode === 'countup' ? 'translateX(100%)' : 'translateX(0)';
   }
-  function loadTasks() {
-    return fetch('/api/study').then((response) => response.json()).then((json) => {
+  function focusJsonSource(source, path, fetchOptions) {
+    if (!source) {
+      return fetch(path, fetchOptions).then((response) => {
+        if (!response.ok) throw new Error('load failed');
+        return response.json();
+      });
+    }
+    return Promise.resolve(source).then((result) => {
+      if (result && result.ok) return result.json;
+      return fetch(path, fetchOptions).then((response) => {
+        if (!response.ok) throw new Error('load failed');
+        return response.json();
+      });
+    });
+  }
+  function loadTasks(options) {
+    const opts = options || {};
+    return focusJsonSource(opts.source, '/api/study').then((json) => {
       tasks = json && Array.isArray(json.tasks) ? json.tasks : [];
       renderTaskOptions();
     }).catch(() => {});
@@ -1288,73 +1349,162 @@
       bindTask(task ? task.id : '', task ? task.title || '' : '', task ? 'study' : '');
     }
   }
-  function loadSessions() {
-    return fetch('/api/focus').then((response) => response.json()).then((json) => {
+  function loadSessions(options) {
+    const opts = options || {};
+    return focusJsonSource(opts.source, '/api/focus').then((json) => {
       sessions = json && Array.isArray(json.sessions) ? json.sessions : [];
       loadedSessions = true;
       renderFootprint();
     }).catch(() => renderFootprint());
   }
 
-  // ── 每日任务侧栏（习惯清单，Tab 开合；与学习任务、.canvas 完全解耦）─────────────
-  function replayDailyPanelEntrance() {
-    if (!dailyRoot || prefersReduced || !dailyOpen) return;
-    clearTimeout(dailyRevealTimer);
+  // ── 专注钟 / 每日任务双视图。页面进入前先稳定最终 DOM，进入后只刷新一次。 ──────────
+  function dailyPayload(json) {
+    const payload = json && json.daily ? json.daily : json;
+    return payload && typeof payload === 'object' ? payload : {};
+  }
+  function dailyPayloadSignature(payload) {
+    return JSON.stringify({
+      tasks: Array.isArray(payload.tasks) ? payload.tasks : [],
+      groups: Array.isArray(payload.groups) ? payload.groups : [],
+    });
+  }
+  function applyDailyPayload(json) {
+    const payload = dailyPayload(json);
+    if (Array.isArray(payload.tasks)) dailyTasks = payload.tasks;
+    if (Array.isArray(payload.groups)) dailyGroups = payload.groups;
+    dailySignature = dailyPayloadSignature({ tasks: dailyTasks, groups: dailyGroups });
+  }
+  function setDailyLoading(loading, reveal) {
+    if (!dailyRoot) return;
+    window.clearTimeout(dailyDataRevealTimer);
+    dailyDataRevealTimer = 0;
+    dailyRoot.classList.toggle('is-loading', !!loading);
+    if (dailyListEl) dailyListEl.setAttribute('aria-busy', loading ? 'true' : 'false');
+    if (!dailySkeletonEl) return;
+    if (loading) {
+      dailyRoot.classList.remove('is-data-revealing');
+      dailySkeletonEl.hidden = false;
+      return;
+    }
+    if (reveal && !prefersReduced && !dailySkeletonEl.hidden && focusPageActive() && viewMode === 'daily') {
+      dailyRoot.classList.add('is-data-revealing');
+      dailyDataRevealTimer = window.setTimeout(() => {
+        dailyRoot.classList.remove('is-data-revealing');
+        dailySkeletonEl.hidden = true;
+        dailyDataRevealTimer = 0;
+      }, 520);
+    } else {
+      dailyRoot.classList.remove('is-data-revealing');
+      dailySkeletonEl.hidden = true;
+    }
+  }
+  function armDailyViewEntranceCleanup() {
+    window.clearTimeout(dailyRevealTimer);
+    dailyRevealTimer = window.setTimeout(() => {
+      if (dailyRoot) dailyRoot.classList.remove('is-revealing');
+      dailyRevealTimer = 0;
+      dailyRevealWaitingForData = false;
+    }, 1450);
+  }
+  function replayDailyViewEntrance(key, options) {
+    if (!dailyRoot || prefersReduced || viewMode !== 'daily' || !focusPageActive()) return;
+    const opts = options || {};
+    const revealKey = String(key || 'manual');
+    if (dailyRevealKey === revealKey) {
+      if (dailyRevealWaitingForData && !opts.waitForData) {
+        dailyRevealWaitingForData = false;
+        armDailyViewEntranceCleanup();
+      }
+      return;
+    }
+    dailyRevealKey = revealKey;
+    window.clearTimeout(dailyRevealTimer);
     dailyRoot.classList.remove('is-revealing');
     void dailyRoot.offsetWidth;
     dailyRoot.classList.add('is-revealing');
-    dailyRevealTimer = setTimeout(() => {
-      if (dailyRoot) dailyRoot.classList.remove('is-revealing');
+    dailyRevealWaitingForData = !!opts.waitForData;
+    if (!dailyRevealWaitingForData) armDailyViewEntranceCleanup();
+  }
+  function clearViewTransition(sync) {
+    viewTransitionSeq += 1;
+    window.clearTimeout(viewTransitionTimer);
+    viewTransitionTimer = 0;
+    [timerViewEl, dailyRoot].forEach((element) => {
+      if (element) element.classList.remove('is-view-entering', 'is-view-exiting');
+    });
+    root.classList.remove('focus-view-transition');
+    if (sync !== false) syncViewAccessibility();
+  }
+  function commitViewMode(next, options) {
+    const opts = options || {};
+    viewMode = next === 'daily' ? 'daily' : 'timer';
+    if (opts.persist !== false) {
+      try { localStorage.setItem(VIEW_MODE_KEY, viewMode); } catch (e) {}
+    }
+    root.classList.toggle('focus-view-daily', viewMode === 'daily');
+    syncViewAccessibility({ keepBoth: !!opts.keepBoth });
+    if (viewMode === 'daily') {
+      toggleSettings(false);
+      toggleHelp(false);
+      closeSessionEditor();
+      if (!dailyLoaded) setDailyLoading(true);
+    } else {
+      endDailyPointerDrag(null, false);
+      closeDailyHistory();
+      closeDailyDetail({ restore: false });
+      closeDailyComposer({ focus: false });
+      window.clearTimeout(dailyRevealTimer);
       dailyRevealTimer = 0;
-    }, 980);
-  }
-  function setDailyOpen(open) {
-    const wasOpen = dailyOpen;
-    if (open && !wasOpen) rememberDailyFocus();
-    dailyOpen = !!open;
-    if (dailyRoot) {
-      if (dailyOpen) {
-        dailyRoot.hidden = false; void dailyRoot.offsetWidth;
-        dailyRoot.classList.remove('is-closing');
-        dailyRoot.classList.add('is-open');
-      } else if (wasOpen) {
-        endDailyPointerDrag(null, false);
-        clearTimeout(dailyRevealTimer);
-        dailyRoot.classList.remove('is-revealing', 'is-peeking');
-        closeDailyHistory();
-        closeDailyDetail({ restore: false });
-        if (prefersReduced) {
-          dailyRoot.classList.remove('is-open');
-        } else {
-          dailyRoot.classList.add('is-closing');
-          const finish = () => {
-            dailyRoot.classList.remove('is-open', 'is-closing');
-            dailyRoot.removeEventListener('animationend', finish);
-          };
-          dailyRoot.addEventListener('animationend', finish, { once: true });
-          clearTimeout(dailyRevealTimer);
-          dailyRevealTimer = setTimeout(finish, 400);
-        }
-      }
-      syncDailyPanelFocusability();
-    }
-    if (bookView) bookView.classList.toggle('focus-daily-open', dailyOpen);
-    if (dailyHandle) dailyHandle.setAttribute('aria-expanded', dailyOpen ? 'true' : 'false');
-    if (dailyOpen) {
-      if (!dailyLoaded) {
-        loadDaily().then(() => replayDailyPanelEntrance());
-      } else {
-        renderDaily({ opening: true });
-        replayDailyPanelEntrance();
-      }
-      if (dailyInputEl && !dailyTasks.length) setTimeout(() => dailyInputEl.focus(), 220);
-      else setTimeout(settleDailyPanelFocus, 80);
-    } else if (wasOpen) {
-      restoreDailyFocus();
+      dailyRevealWaitingForData = false;
+      if (dailyRoot) dailyRoot.classList.remove('is-revealing');
     }
   }
-  function toggleDaily(force) {
-    setDailyOpen(typeof force === 'boolean' ? force : !dailyOpen);
+  function setViewMode(mode, options) {
+    const opts = options || {};
+    const next = mode === 'daily' ? 'daily' : 'timer';
+    if (next === viewMode && !root.classList.contains('focus-view-transition')) {
+      syncViewAccessibility();
+      return true;
+    }
+    if (next === 'daily' && sessionLocksView() && !opts.force) {
+      toast('请先完成收尾或重置当前专注段，再查看每日任务');
+      return false;
+    }
+    const outgoing = viewMode === 'daily' ? dailyRoot : timerViewEl;
+    const incoming = next === 'daily' ? dailyRoot : timerViewEl;
+    const animate = opts.animate !== false && !prefersReduced && focusPageActive() && outgoing && incoming;
+    clearViewTransition(true);
+    if (!animate) {
+      commitViewMode(next, opts);
+      if (next === 'daily' && !dailyLoaded && opts.load !== false) {
+        loadDaily({ reveal: true, entrance: false });
+      }
+      return true;
+    }
+    const transitionId = ++viewTransitionSeq;
+    commitViewMode(next, Object.assign({}, opts, { keepBoth: true }));
+    root.classList.add('focus-view-transition');
+    outgoing.classList.add('is-view-exiting');
+    incoming.classList.add('is-view-entering');
+    if (next === 'daily') {
+      if (!dailyLoaded && opts.load !== false) loadDaily({ reveal: true, entrance: false });
+    }
+    viewTransitionTimer = window.setTimeout(() => {
+      if (transitionId !== viewTransitionSeq) return;
+      outgoing.classList.remove('is-view-exiting');
+      incoming.classList.remove('is-view-entering');
+      root.classList.remove('focus-view-transition');
+      syncViewAccessibility();
+      viewTransitionTimer = 0;
+    }, 560);
+    return true;
+  }
+  function toggleViewMode() {
+    return setViewMode(viewMode === 'daily' ? 'timer' : 'daily', { persist: true, animate: true });
+  }
+  function showTimerView(options) {
+    return setViewMode('timer', Object.assign({ persist: false, animate: false, force: true }, options || {}));
   }
   function allDailyDone() {
     return dailyTasks.length > 0 && dailyTasks.every((task) => task.doneToday);
@@ -1362,41 +1512,69 @@
   function dailyTodayMinutesTotal() {
     return dailyTasks.reduce((sum, task) => sum + (Number(task.todayMinutes) || 0), 0);
   }
-  function applyDailyPayload(json) {
-    const payload = json && json.daily ? json.daily : json;
-    if (payload && Array.isArray(payload.tasks)) dailyTasks = payload.tasks;
-    if (payload && Array.isArray(payload.groups)) dailyGroups = payload.groups;
-  }
-  function loadDaily() {
-    return fetch('/api/daily').then((response) => response.json()).then((json) => {
-      dailyTasks = json && Array.isArray(json.tasks) ? json.tasks : [];
-      dailyGroups = json && Array.isArray(json.groups) ? json.groups : [];
-      dailyLoaded = true;
-      dailyWasAllDone = allDailyDone();
-      renderDaily({ initial: true });
+  function loadDaily(options) {
+    const opts = options || {};
+    const requestId = ++dailyRequestSeq;
+    if (dailyRequestController) dailyRequestController.abort();
+    const controller = typeof AbortController === 'function' ? new AbortController() : null;
+    dailyRequestController = controller;
+    const wasLoaded = dailyLoaded;
+    if (!wasLoaded && viewMode === 'daily') setDailyLoading(true);
+    const fetchOptions = controller ? { signal: controller.signal } : undefined;
+    return focusJsonSource(opts.source, '/api/daily', fetchOptions).then((json) => {
+      if (requestId !== dailyRequestSeq) return false;
+      const payload = dailyPayload(json);
+      const nextSignature = dailyPayloadSignature(payload);
+      const changed = !wasLoaded || nextSignature !== dailySignature;
+      if (changed) {
+        applyDailyPayload(payload);
+        dailyLoaded = true;
+        dailyWasAllDone = allDailyDone();
+        renderDaily({ initial: !wasLoaded, flip: wasLoaded });
+      }
       renderTaskOptions();
-    }).catch(() => {});
+      setDailyLoading(false, !wasLoaded && opts.reveal !== false);
+      if (!wasLoaded && viewMode === 'daily' && focusLifecycleActive
+        && opts.reveal !== false && opts.entrance !== false) {
+        replayDailyViewEntrance(opts.revealKey || ('load-' + focusActivationSeq), { waitForData: false });
+      }
+      return changed;
+    }).catch((error) => {
+      if (error && error.name === 'AbortError') return false;
+      if (requestId === dailyRequestSeq) {
+        setDailyLoading(false, false);
+        if (!wasLoaded && opts.entrance !== false) {
+          replayDailyViewEntrance(opts.revealKey || ('load-' + focusActivationSeq), { waitForData: false });
+        }
+        if (!dailyLoaded && !opts.quiet) toast(error.message || '每日任务载入失败');
+      }
+      return false;
+    }).finally(() => {
+      if (requestId === dailyRequestSeq) dailyRequestController = null;
+    });
+  }
+
+  function preloadFocusView() {
+    if (focusWarmupPromise) return focusWarmupPromise;
+    focusWarmupPromise = Promise.allSettled([
+      loadTasks({ source: bootFocusData.study }),
+      loadDaily({ source: bootFocusData.daily, reveal: false, entrance: false, quiet: true }),
+      loadSessions({ source: bootFocusData.sessions }),
+    ]);
+    return focusWarmupPromise;
   }
 
   function renderDaily(opts) {
     opts = opts || {};
-    if (!dailyListEl || dailyClearing) return;
-    const allDone = allDailyDone();
-    if (!allDone) dailyPeek = false;
-    const became = allDone && !dailyWasAllDone && !opts.initial;
-    dailyWasAllDone = allDone;
-    rebuildDailyRows({ flip: !opts.initial && dailyOpen });
-    syncDailyPanelFocusability();
+    if (!dailyListEl) return;
+    rebuildDailyRows({ flip: opts.flip !== false && !opts.initial && viewMode === 'daily' });
+    syncViewAccessibility();
+    if (dailyCountEl) dailyCountEl.textContent = String(dailyTasks.length);
     updateDailyFoot();
     updateDailyComposeUI();
     renderDailyHistory();
     renderDailyDetail();
-    if (allDone && !dailyPeek) {
-      if (became && !prefersReduced) startDailyClear();
-      else showDailyCelebrate(false);
-    } else {
-      hideDailyCelebrate();
-    }
+    dailyCelebrationCheck({ animate: !!opts.celebrate && !opts.initial });
   }
   // FLIP 的身份键：任务用 t:id，分组头用 g:id，二者同列参与位移动画（折叠/重排都顺滑）
   function dailyFlipKey(el) {
@@ -1529,20 +1707,23 @@
   }
   function buildDailyRows() {
     dailyListEl.innerHTML = '';
+    if (dailyRoot) dailyRoot.style.setProperty('--daily-exit-tail', '0');
     if (!dailyTasks.length && !dailyGroups.length) {
       const empty = document.createElement('p');
       empty.className = 'focus-daily-empty';
-      empty.textContent = '还没有每日任务 · 在下面加一件想每天坚持的事';
+      empty.textContent = '还没有每日任务 · 点右上角“＋”加一件想每天坚持的事';
       dailyListEl.appendChild(empty);
       return;
     }
     // 借鉴博客分类树：每层先列子分组，再列本层任务。子树渲进 .focus-daily-group-children 容器，
     // 始终渲染（即便折叠），折叠交给 CSS grid-rows 平滑收合——不再靠重建，避免子项瞬移。
     let index = 0;
-    const renderInto = (container, parentId, depth) => {
+    const visibleExitNodes = [];
+    const renderInto = (container, parentId, depth, visible) => {
       dailyChildGroups(parentId).forEach((group) => {
         const wrap = buildDailyGroupRow(group, depth);
-        wrap.style.setProperty('--daily-row-index', String(index++));
+        wrap.style.setProperty('--daily-row-index', String(Math.min(index++, 7)));
+        if (visible) visibleExitNodes.push(wrap);
         container.appendChild(wrap);
         const childrenWrap = document.createElement('div');
         childrenWrap.className = 'focus-daily-group-children';
@@ -1551,15 +1732,23 @@
         if (group.collapsed) inner.setAttribute('inert', '');   // 折叠子树不可聚焦/点击
         childrenWrap.appendChild(inner);
         wrap.appendChild(childrenWrap);
-        renderInto(inner, group.id, depth + 1);
+        renderInto(inner, group.id, depth + 1, visible && !group.collapsed);
       });
       dailyDirectTasks(parentId).forEach((task) => {
         const row = buildDailyRow(task, depth);
-        row.style.setProperty('--daily-row-index', String(index++));
+        row.style.setProperty('--daily-row-index', String(Math.min(index++, 7)));
+        if (visible) visibleExitNodes.push(row);
         container.appendChild(row);
       });
     };
-    renderInto(dailyListEl, '', 0);
+    renderInto(dailyListEl, '', 0, true);
+    const exitTail = Math.min(Math.max(visibleExitNodes.length - 1, 0), 8);
+    visibleExitNodes.forEach((element, visibleIndex) => {
+      element.style.setProperty('--daily-exit-order', String(Math.min(
+        Math.max(visibleExitNodes.length - 1 - visibleIndex, 0), 8
+      )));
+    });
+    if (dailyRoot) dailyRoot.style.setProperty('--daily-exit-tail', String(exitTail));
     dailyEnterId = '';   // 入场动画只播一次
   }
   function buildDailyGroupRow(group, depth) {
@@ -2392,7 +2581,9 @@
     check.className = 'focus-daily-check';
     check.dataset.role = 'daily-check';
     check.setAttribute('aria-pressed', task.doneToday ? 'true' : 'false');
-    check.setAttribute('aria-label', (task.doneToday ? '取消完成 · ' : '标记完成 · ') + (task.name || '每日任务'));
+    const checkLabel = (task.doneToday ? '取消完成 · ' : '标记完成 · ') + (task.name || '每日任务');
+    check.setAttribute('data-i18n-source-aria-label', checkLabel);
+    check.setAttribute('aria-label', T(checkLabel));
     row.appendChild(check);
 
     const main = document.createElement('div');
@@ -2746,77 +2937,162 @@
   function updateDailyFoot() {
     if (!dailyFootEl) return;
     const T = (window.RelatumI18n && window.RelatumI18n.t) || function (s) { return s; };
-    if (!dailyTasks.length) { dailyFootEl.textContent = ''; return; }
+    if (!dailyTasks.length || (allDailyDone() && !dailyReviewedToday())) {
+      dailyFootEl.textContent = '';
+      dailyFootEl.hidden = true;
+      return;
+    }
     const done = dailyTasks.filter((task) => task.doneToday).length;
     const mins = dailyTodayMinutesTotal();
     dailyFootEl.textContent = T('今天 ' + done + ' / ' + dailyTasks.length + ' 完成'
       + (mins > 0 ? ' · 今日已专注 ' + mins + ' 分' : ''));
+    // 撤销最后一项完成时，先让完成落款自然收拢，再接回普通汇总，避免两份统计短暂叠在一起。
+    dailyFootEl.hidden = dailyCelebratePhase !== 'hidden';
   }
   function pulseDailyFoot() {
     if (!dailyFootEl || prefersReduced) return;
     replayClass(dailyFootEl, 'is-updating');
   }
-  function startDailyClear(settleDelay) {
-    clearTimeout(dailyClearTimer);
-    dailyClearing = true;
-    if (dailyRoot) dailyRoot.classList.add('is-completing');
-    const items = Array.prototype.slice.call(dailyListEl.children).filter((el) =>
-      el.classList.contains('focus-daily-row') || el.classList.contains('focus-daily-group'));
-    dailyClearTimer = setTimeout(() => {
-      items.forEach((el, index) => {
-        el.classList.remove('is-complete-pop', 'is-reopen-pop');
-        el.style.setProperty('--daily-clear-delay', (index * 76) + 'ms');
-        el.classList.add('is-clearing');
-      });
-      // 末项滑完即触发庆祝，animationend 为主、setTimeout 兜底
-      const last = items[items.length - 1];
-      let fired = false;
-      const reveal = () => { if (!fired) { fired = true; dailyClearing = false; showDailyCelebrate(true); } };
-      if (last && !prefersReduced) last.addEventListener('animationend', reveal, { once: true });
-      dailyClearTimer = setTimeout(reveal, items.length * 76 + 460);
-    }, Math.max(0, Number(settleDelay) || 240));
-  }
-  function showDailyCelebrate(animate) {
+  function updateDailyCelebrateCopy() {
     if (!dailyCelebrateEl) return;
-    if (dailyRoot) dailyRoot.classList.remove('is-completing');
-    if (dailyListEl) dailyListEl.hidden = true;
-    if (dailyAddForm) dailyAddForm.classList.add('is-dimmed');
-    if (dailyFootEl) dailyFootEl.hidden = true;
+    if (dailyCelebrateTitleEl) dailyCelebrateTitleEl.textContent = T('今日清单已全部完成');
     if (dailyCelebrateSubEl) {
       const count = dailyTasks.length;
       const mins = dailyTodayMinutesTotal();
-      dailyCelebrateSubEl.textContent = count + ' 件全部完成'
-        + (mins > 0 ? ' · 专注 ' + mins + ' 分钟' : '') + ' · 明天见';
-    }
-    dailyCelebrateEl.hidden = false;
-    if (animate && !prefersReduced) {
-      if (dailyRoot) replayClass(dailyRoot, 'is-celebrate-ready');
-      replayClass(dailyCelebrateEl, 'is-celebrating');
+      dailyCelebrateSubEl.textContent = T('今天做完了 ' + count + ' 件事'
+        + (mins > 0 ? ' · 专注 ' + mins + ' 分钟' : ''));
     }
   }
-  function hideDailyCelebrate() {
-    clearTimeout(dailyClearTimer);
-    dailyClearing = false;
-    if (dailyRoot) dailyRoot.classList.remove('is-completing', 'is-celebrate-ready');
-    if (dailyCelebrateEl) dailyCelebrateEl.hidden = true;
-    if (dailyListEl) dailyListEl.hidden = false;
-    if (dailyAddForm) dailyAddForm.classList.remove('is-dimmed');
-    if (dailyFootEl) dailyFootEl.hidden = false;
-  }
-  function dailyPeekList() {
-    dailyPeek = true;
-    if (dailyRoot && !prefersReduced) {
-      clearTimeout(dailyRevealTimer);
-      dailyRoot.classList.remove('is-peeking');
-      void dailyRoot.offsetWidth;
-      dailyRoot.classList.add('is-peeking');
-      dailyRevealTimer = setTimeout(() => {
-        if (dailyRoot) dailyRoot.classList.remove('is-peeking');
-        dailyRevealTimer = 0;
-      }, 820);
+  function commitDailyCelebratePhase(phase) {
+    if (!dailyCelebrateEl) return;
+    dailyCelebratePhase = phase;
+    dailyCelebrateEl.dataset.phase = phase;
+    dailyCelebrateEl.setAttribute('aria-hidden', phase === 'hidden' ? 'true' : 'false');
+    if (dailyRoot) {
+      dailyRoot.classList.toggle('is-celebration-open', phase === 'entering' || phase === 'visible');
+      dailyRoot.classList.toggle('is-celebration-entering', phase === 'entering');
+      dailyRoot.classList.toggle('is-celebration-leaving', phase === 'leaving');
     }
-    hideDailyCelebrate();
-    renderDaily();
+    if (dailyScrollEl) {
+      const blocked = phase !== 'hidden';
+      dailyScrollEl.toggleAttribute('inert', blocked);
+      dailyScrollEl.setAttribute('aria-hidden', blocked ? 'true' : 'false');
+    }
+  }
+  function dailyCelebrateReturnTarget() {
+    if (dailyCelebrateReturnId && dailyListEl) {
+      const row = dailyListEl.querySelector('.focus-daily-row[data-id="' + dailyCelebrateReturnId + '"]');
+      const check = row && row.querySelector('.focus-daily-check');
+      if (check) return check;
+    }
+    return dailyScrollEl || dailyCreateBtn || null;
+  }
+  function focusDailyCelebrateAction(delay) {
+    window.clearTimeout(dailyCelebrateFocusTimer);
+    dailyCelebrateFocusTimer = window.setTimeout(() => {
+      dailyCelebrateFocusTimer = 0;
+      if (dailyCelebratePhase === 'hidden' || viewMode !== 'daily' || !focusPageActive()) return;
+      if (dailyReviewBtn) {
+        try { dailyReviewBtn.focus({ preventScroll: true }); }
+        catch (e) { dailyReviewBtn.focus(); }
+      }
+    }, Math.max(0, Number(delay) || 0));
+  }
+  function restoreDailyCelebrateFocus() {
+    const target = dailyCelebrateReturnTarget();
+    dailyCelebrateReturnId = '';
+    if (!target || !target.isConnected || viewMode !== 'daily' || !focusPageActive()) return;
+    try { target.focus({ preventScroll: true }); }
+    catch (e) { target.focus(); }
+  }
+  function showDailyCelebrate(animate) {
+    if (!dailyCelebrateEl) return;
+    updateDailyCelebrateCopy();
+    if (dailyReviewedToday()) {
+      hideDailyCelebrate({ instant: true, restoreFocus: false });
+      return;
+    }
+
+    // 接口回包会再次同步同一份完成态。进入动画尚未结束时只更新文案，
+    // 不能递增 generation、清计时器或移除 is-entering，否则动画会被截成硬切。
+    if (dailyCelebratePhase === 'entering' || dailyCelebratePhase === 'visible') return;
+
+    const generation = ++dailyCelebrateGeneration;
+    window.clearTimeout(dailyCelebrateMotionTimer);
+    window.clearTimeout(dailyCelebrateHideTimer);
+    window.clearTimeout(dailyCelebrateFocusTimer);
+    dailyCelebrateMotionTimer = 0;
+    dailyCelebrateHideTimer = 0;
+    dailyCelebrateFocusTimer = 0;
+    dailyCelebrateEl.classList.remove('is-leaving', 'is-static');
+
+    if (!animate || prefersReduced) {
+      dailyCelebrateEl.classList.remove('is-entering');
+      dailyCelebrateEl.classList.add('is-visible', 'is-static');
+      commitDailyCelebratePhase('visible');
+      // is-static 只屏蔽这一次恢复的 transition；可见状态不变后再移除不会补播动画。
+      window.requestAnimationFrame(() => {
+        if (generation !== dailyCelebrateGeneration || !dailyCelebrateEl) return;
+        dailyCelebrateEl.classList.remove('is-static');
+      });
+      return;
+    }
+
+    dailyCelebrateEl.classList.remove('is-entering');
+    void dailyCelebrateEl.offsetWidth;
+    dailyCelebrateEl.classList.add('is-visible', 'is-entering');
+    commitDailyCelebratePhase('entering');
+    focusDailyCelebrateAction(1720);
+    dailyCelebrateMotionTimer = window.setTimeout(() => {
+      if (generation !== dailyCelebrateGeneration || !dailyCelebrateEl) return;
+      dailyCelebrateEl.classList.remove('is-entering');
+      commitDailyCelebratePhase('visible');
+      dailyCelebrateMotionTimer = 0;
+    }, 2360);
+  }
+  function hideDailyCelebrate(options) {
+    const opts = options || {};
+    if (!dailyCelebrateEl) return;
+    if (dailyCelebratePhase === 'hidden') {
+      commitDailyCelebratePhase('hidden');
+      updateDailyFoot();
+      if (opts.restoreFocus) restoreDailyCelebrateFocus();
+      return;
+    }
+    const generation = ++dailyCelebrateGeneration;
+    window.clearTimeout(dailyCelebrateMotionTimer);
+    window.clearTimeout(dailyCelebrateHideTimer);
+    window.clearTimeout(dailyCelebrateFocusTimer);
+    dailyCelebrateMotionTimer = 0;
+    dailyCelebrateHideTimer = 0;
+    dailyCelebrateFocusTimer = 0;
+    dailyCelebrateEl.classList.remove('is-entering', 'is-static');
+    if (prefersReduced || opts.instant) {
+      dailyCelebrateEl.classList.remove('is-visible', 'is-leaving');
+      commitDailyCelebratePhase('hidden');
+      updateDailyFoot();
+      if (opts.restoreFocus) restoreDailyCelebrateFocus();
+      return;
+    }
+    dailyCelebrateEl.classList.add('is-leaving');
+    dailyCelebrateEl.classList.remove('is-visible');
+    commitDailyCelebratePhase('leaving');
+    dailyCelebrateHideTimer = window.setTimeout(() => {
+      if (generation !== dailyCelebrateGeneration || !dailyCelebrateEl) return;
+      dailyCelebrateEl.classList.remove('is-leaving');
+      commitDailyCelebratePhase('hidden');
+      dailyCelebrateHideTimer = 0;
+      updateDailyFoot();
+      if (opts.restoreFocus) restoreDailyCelebrateFocus();
+    }, 280);
+  }
+  function reviewDailyCelebration() {
+    if (!allDailyDone()) {
+      hideDailyCelebrate({ restoreFocus: true });
+      return;
+    }
+    setDailyReviewedToday(true);
+    hideDailyCelebrate({ restoreFocus: true });
   }
   function makeDailyDragGhost(row, rect) {
     const ghost = row.cloneNode(true);
@@ -3089,9 +3365,21 @@
     clearDailyDropInto();
     dailyDrag = null;
     try { d.row.releasePointerCapture(d.pointerId); } catch (e) {}
-    if (!d.active) return;
+    if (!d.active) {
+      if (d.ghost) d.ghost.remove();
+      return;
+    }
     if (event && event.preventDefault) event.preventDefault();
     if (document.body) document.body.classList.remove('focus-daily-dragging');
+    if (!commit && !event) {
+      if (d.ghost) d.ghost.remove();
+      if (dailyListEl) {
+        dailyListEl.querySelectorAll('.is-dragging, .is-drag-subtree').forEach((element) => {
+          element.classList.remove('is-dragging', 'is-drag-subtree');
+        });
+      }
+      return;
+    }
     dailySuppressClick = true;
     setTimeout(() => { dailySuppressClick = false; }, 0);
     const changed = !!(t && t.valid) && applyDailyDrop(d, t);
@@ -3132,7 +3420,7 @@
       return;
     }
     if (event.button !== 0 || dailyEditId || dailyGroupEditId || dailyConfirmDeleteId
-        || dailyGroupConfirmDeleteId || dailyClearing || dailyDrag) return;
+        || dailyGroupConfirmDeleteId || dailyDrag) return;
     // 这些控件是纯点击，不从它们起拖（勾选 / 编辑器内部 / 折叠箭头 / ⋯菜单）
     if (event.target.closest('[data-role="daily-check"], [data-role="daily-history"], [data-role="daily-menu"], .focus-daily-edit, .focus-daily-milestone, [data-role="daily-group-toggle"], [data-role="daily-group-menu"]')) return;
     const taskRow = event.target.closest('.focus-daily-row');
@@ -3165,15 +3453,6 @@
     window.addEventListener('pointercancel', onDailyPointerCancel);
   }
 
-  // 点任务名/空白处的轻反馈：不改状态，只让 ⋯ 轻跳一下（提示编辑入口），尊重 reduced-motion。
-  function hintDailyRow(row) {
-    if (!row || prefersReduced) return;
-    row.classList.remove('is-hint');
-    void row.offsetWidth;   // 重启动画
-    row.classList.add('is-hint');
-    window.clearTimeout(dailyHintTimers.get(row));
-    dailyHintTimers.set(row, window.setTimeout(() => row.classList.remove('is-hint'), 640));
-  }
   function openDailyEdit(id) {
     const task = dailyTasks.find((item) => item.id === id);
     dailyEditId = id;
@@ -3285,18 +3564,25 @@
   }
   function createDailyTask(name, groupId) {
     name = (name || '').trim();
-    if (!name) return;
+    if (!name || dailyCreatePending) return;
+    setDailyCreatePending(true);
     const prevIds = dailyTasks.map((task) => task.id);
     post('/api/daily-create', { name: name, groupId: groupId || '' })
       .then((json) => {
         applyDailyPayload(json);
         const fresh = dailyTasks.find((task) => prevIds.indexOf(task.id) < 0);
         dailyEnterId = fresh ? fresh.id : '';
-        if (dailyInputEl) { dailyInputEl.value = ''; dailyInputEl.focus(); }
+        if (dailyInputEl) dailyInputEl.value = '';
+        setDailyCreatePending(false);
+        closeDailyComposer({ focus: true });
         renderDaily();
         renderTaskOptions();
       })
-      .catch((error) => toast(error.message));
+      .catch((error) => {
+        setDailyCreatePending(false);
+        toast(error.message);
+        if (dailyInputEl) dailyInputEl.focus();
+      });
   }
   // 分组就地展开时让直接子项「一个一个」逐步揭示（与面板打开的逐行入场同手法），
   // 而非整块一起冒出。临时加 .is-expanding + 逐项 --daily-expand-index 驱动交错，结束后清理。
@@ -3334,6 +3620,7 @@
   function setDailyGroupCollapsed(gid, collapsed) {
     const group = dailyGroupById(gid);
     if (!group) return;
+    const previous = !!group.collapsed;
     group.collapsed = collapsed;
     const wrap = dailyListEl.querySelector('.focus-daily-group[data-group-id="' + gid + '"]');
     if (wrap) {
@@ -3353,8 +3640,15 @@
     } else {
       rebuildDailyRows({ flip: false });
     }
-    syncDailyPanelFocusability();
-    post('/api/daily-group-update', { id: gid, collapsed: collapsed }).catch(() => {});
+    syncViewAccessibility();
+    post('/api/daily-group-update', { id: gid, collapsed: collapsed })
+      .then((json) => applyDailyPayload(json))
+      .catch((error) => {
+        const current = dailyGroupById(gid);
+        if (current) current.collapsed = previous;
+        rebuildDailyRows({ flip: true });
+        toast(error.message || '分组状态保存失败');
+      });
   }
   function toggleDailyGroupCollapse(gid) {
     const group = dailyGroupById(gid);
@@ -3403,12 +3697,22 @@
     const nameIn = wrap.querySelector('[data-role="daily-group-edit-name"]');
     const name = (nameIn ? nameIn.value : '').trim();
     if (!name) { if (nameIn) nameIn.focus(); toast('分组名不能为空'); return; }
-    dailyGroupEditId = '';
-    dailyGroupConfirmDeleteId = '';
-    rebuildDailyRows({ flip: true });
+    const edit = wrap.querySelector('.focus-daily-group-edit');
+    if (edit && edit.classList.contains('is-saving')) return;
+    if (edit) edit.classList.add('is-saving');
     post('/api/daily-group-update', { id: gid, name: name })
-      .then((json) => { applyDailyPayload(json); renderDaily(); renderTaskOptions(); })
-      .catch((error) => toast(error.message));
+      .then((json) => {
+        dailyGroupEditId = '';
+        dailyGroupConfirmDeleteId = '';
+        applyDailyPayload(json);
+        renderDaily();
+        renderTaskOptions();
+      })
+      .catch((error) => {
+        if (edit) edit.classList.remove('is-saving');
+        toast(error.message);
+        if (nameIn) nameIn.focus();
+      });
   }
   function requestDeleteDailyGroup(gid) {
     dailyGroupConfirmDeleteId = gid;
@@ -3435,22 +3739,55 @@
   }
   function createDailyGroup(name, parentId) {
     name = (name || '').trim();
-    if (!name) return;
+    if (!name || dailyCreatePending) return;
+    setDailyCreatePending(true);
     const prevIds = dailyGroups.map((g) => g.id);
     post('/api/daily-group-create', { name: name, parentId: parentId || '' })
       .then((json) => {
         applyDailyPayload(json);
         const fresh = dailyGroups.find((g) => prevIds.indexOf(g.id) < 0);
         dailyEnterId = fresh ? fresh.id : '';
-        if (dailyInputEl) { dailyInputEl.value = ''; dailyInputEl.focus(); }
-        setDailyCompose('task', '');   // 建完分组回到「任务」模式
+        if (dailyInputEl) dailyInputEl.value = '';
+        dailyComposeMode = 'task';
+        dailyAddTargetGroup = '';
+        setDailyCreatePending(false);
+        closeDailyComposer({ focus: true });
         renderDaily();
         renderTaskOptions();
       })
-      .catch((error) => toast(error.message));
+      .catch((error) => {
+        setDailyCreatePending(false);
+        toast(error.message);
+        if (dailyInputEl) dailyInputEl.focus();
+      });
+  }
+  function openDailyComposer(mode, targetGroupId) {
+    dailyComposerOpen = true;
+    if (dailyComposerEl) dailyComposerEl.hidden = false;
+    if (dailyCreateBtn) dailyCreateBtn.setAttribute('aria-expanded', 'true');
+    setDailyCompose(mode || dailyComposeMode, targetGroupId == null ? dailyAddTargetGroup : targetGroupId);
+  }
+  function closeDailyComposer(options) {
+    const opts = options || {};
+    dailyComposerOpen = false;
+    dailyAddTargetGroup = '';
+    dailyComposeMode = 'task';
+    if (dailyComposerEl) dailyComposerEl.hidden = true;
+    if (dailyCreateBtn) dailyCreateBtn.setAttribute('aria-expanded', 'false');
+    if (dailyInputEl) dailyInputEl.value = '';
+    updateDailyComposeUI();
+    if (opts.focus !== false && dailyCreateBtn && dailyCreateBtn.isConnected) dailyCreateBtn.focus();
+  }
+  function toggleDailyComposer() {
+    if (dailyCreatePending) return;
+    if (dailyComposerOpen) closeDailyComposer({ focus: true });
+    else openDailyComposer('task', '');
   }
   // 新增控制条：在「任务 / 分组」两种模式 + 目标父分组之间切换，复用同一个输入框
   function setDailyCompose(mode, targetGroupId) {
+    dailyComposerOpen = true;
+    if (dailyComposerEl) dailyComposerEl.hidden = false;
+    if (dailyCreateBtn) dailyCreateBtn.setAttribute('aria-expanded', 'true');
     dailyComposeMode = mode === 'group' ? 'group' : 'task';
     dailyAddTargetGroup = targetGroupId || '';
     let needRebuild = false;
@@ -3474,6 +3811,8 @@
     if (dailyInputEl) dailyInputEl.focus();
   }
   function updateDailyComposeUI() {
+    if (dailyComposerEl) dailyComposerEl.hidden = !dailyComposerOpen;
+    if (dailyCreateBtn) dailyCreateBtn.setAttribute('aria-expanded', dailyComposerOpen ? 'true' : 'false');
     const isGroup = dailyComposeMode === 'group';
     if (dailyComposeTaskBtn) {
       dailyComposeTaskBtn.classList.toggle('is-active', !isGroup);
@@ -3506,21 +3845,39 @@
         ? (target ? '在「' + (target.name || '分组') + '」下新建子分组…' : '新建分组名称…')
         : (target ? '在「' + (target.name || '分组') + '」下添加任务…' : '添加一件今天想坚持的事…');
     }
+    if (dailySubmitBtn) dailySubmitBtn.setAttribute('aria-label', isGroup ? '添加分组' : '添加每日任务');
   }
-  // 勾选只切换该行的完成态（不整列重建），对勾弹入与删除线生长才有过渡；
-  // 统计数字等服务端真值回来后就地补，不打断动画。全部完成的清场/庆祝照旧判定。
+  function setDailyCreatePending(pending) {
+    dailyCreatePending = !!pending;
+    if (dailyComposerEl) dailyComposerEl.classList.toggle('is-pending', dailyCreatePending);
+    if (dailyInputEl) dailyInputEl.disabled = dailyCreatePending;
+    if (dailySubmitBtn) {
+      dailySubmitBtn.disabled = dailyCreatePending;
+      dailySubmitBtn.setAttribute('aria-busy', dailyCreatePending ? 'true' : 'false');
+    }
+    if (dailyCreateBtn) dailyCreateBtn.disabled = dailyCreatePending;
+    [dailyComposeTaskBtn, dailyComposeGroupBtn, dailyComposeTargetBtn].forEach((button) => {
+      if (button) button.disabled = dailyCreatePending;
+    });
+  }
+  // 勾选只切换该行的完成态；全部完成时保留原位清单，只追加有限反馈。
   function dailyCelebrationCheck(options) {
     const opts = options || {};
     const allDone = allDailyDone();
-    if (!allDone) dailyPeek = false;
     const became = allDone && !dailyWasAllDone;
     dailyWasAllDone = allDone;
-    if (allDone && !dailyPeek) {
-      if (became && !prefersReduced) startDailyClear(opts.waitForMilestone ? 1420 : (opts.waitForGoal ? 860 : 240));
-      else showDailyCelebrate(false);
-    } else {
+    if (!allDone) {
+      setDailyReviewedToday(false);
       hideDailyCelebrate();
+      return;
     }
+    if (dailyReviewedToday()) {
+      if (dailyCelebratePhase !== 'leaving') {
+        hideDailyCelebrate({ instant: dailyCelebratePhase === 'hidden', restoreFocus: false });
+      }
+      return;
+    }
+    showDailyCelebrate(opts.animate === false ? false : became);
   }
   function setRowDone(row, done) {
     if (!row) return;
@@ -3528,13 +3885,16 @@
     const check = row.querySelector('.focus-daily-check');
     if (check) {
       const task = dailyTasks.find((item) => item.id === row.dataset.id);
+      const checkLabel = (done ? '取消完成 · ' : '标记完成 · ') + (task && task.name || '每日任务');
       check.setAttribute('aria-pressed', done ? 'true' : 'false');
-      check.setAttribute('aria-label', (done ? '取消完成 · ' : '标记完成 · ') + (task && task.name || '每日任务'));
+      // i18n 的属性观察器会保留首次见到的中文源文本；同步更新源值，
+      // 避免快速勾选后把新的按钮状态翻译回旧的 “Undo / Mark done”。
+      check.setAttribute('data-i18n-source-aria-label', checkLabel);
+      check.setAttribute('aria-label', T(checkLabel));
     }
     if (!prefersReduced) {
-      replayClass(row, done ? 'is-complete-pop' : 'is-reopen-pop');
-      const stat = row.querySelector('.focus-daily-stat');
-      replayClass(stat, 'is-updating');
+      row.classList.remove('is-complete-pop', 'is-reopen-pop');
+      replayClass(row, done ? 'is-complete-pop' : 'is-reopen-pop', 520);
     }
   }
   function refreshDailyRowStats(task, options) {
@@ -3557,36 +3917,80 @@
       toggle.textContent = task.doneToday ? T('取消今日打卡') : T('今日打卡');
     }
   }
-  // 三期：把刚因这次勾选而「整组完成」的最高祖先组自动收起。延迟到对勾/删除线动画走完；
-  // 期间被改动或正在拖拽就放弃，手动展开不打扰（全清则交给庆祝流程）。
-  function maybeAutoCollapseCompletedGroup(taskId) {
-    if (allDailyDone()) return;
-    const task = dailyTasks.find((t) => t.id === taskId);
-    if (!task || !task.doneToday || !task.groupId) return;
-    let target = '';
-    let cur = task.groupId;
-    const guard = new Set();
-    while (cur && !guard.has(cur)) {
-      guard.add(cur);
-      const prog = dailyGroupProgress(cur);
-      if (prog.total > 0 && prog.done === prog.total) target = cur; else break;
-      cur = (dailyGroupById(cur) || {}).parentId || '';
+  function syncDailyToggleResult(id, task) {
+    const row = dailyListEl.querySelector('.focus-daily-row[data-id="' + id + '"]');
+    setRowDone(row, !!task.doneToday);
+    refreshDailyRowStats(task);
+    refreshDailyDetailGoal(task);
+    refreshDailyGroupProgress(task.groupId);
+    updateDailyFoot();
+    renderDailyHistory();
+    dailyCelebrationCheck();
+    renderTaskOptions();
+  }
+  function finishDailyToggleState(id, state) {
+    if (dailyToggleStates.get(id) === state) dailyToggleStates.delete(id);
+    const row = dailyListEl.querySelector('.focus-daily-row[data-id="' + id + '"]');
+    if (row) row.classList.remove('is-syncing');
+  }
+  function drainDailyToggle(id, state) {
+    if (!state || state.inFlight || dailyToggleStates.get(id) !== state) return;
+    if (!!state.desired === !!state.confirmedTask.doneToday) {
+      const current = dailyTasks.find((item) => item.id === id);
+      if (current) Object.assign(current, JSON.parse(JSON.stringify(state.confirmedTask)));
+      dailySignature = dailyPayloadSignature({ tasks: dailyTasks, groups: dailyGroups });
+      if (current) syncDailyToggleResult(id, current);
+      finishDailyToggleState(id, state);
+      return;
     }
-    if (!target) return;
-    const g = dailyGroupById(target);
-    if (!g || g.collapsed) return;
-    setTimeout(() => {
-      const gg = dailyGroupById(target);
-      if (!gg || gg.collapsed || dailyClearing || dailyDrag) return;
-      const prog = dailyGroupProgress(target);
-      if (!(prog.total > 0 && prog.done === prog.total)) return;
-      setDailyGroupCollapsed(target, true);   // 走 CSS 平滑收合
-    }, 480);
+    const target = !!state.desired;
+    state.inFlight = true;
+    post('/api/daily-toggle', { id: id, done: target }).then((json) => {
+      if (dailyToggleStates.get(id) !== state) return;
+      const payload = dailyPayload(json);
+      const confirmed = Array.isArray(payload.tasks) ? payload.tasks.find((item) => item.id === id) : null;
+      if (confirmed) state.confirmedTask = JSON.parse(JSON.stringify(confirmed));
+      else state.confirmedTask.doneToday = target;
+      state.inFlight = false;
+      if (!!state.desired !== target) {
+        drainDailyToggle(id, state);
+        return;
+      }
+      applyDailyPayload(payload);
+      const fresh = dailyTasks.find((item) => item.id === id);
+      if (fresh) syncDailyToggleResult(id, fresh);
+      finishDailyToggleState(id, state);
+    }).catch((error) => {
+      if (dailyToggleStates.get(id) !== state) return;
+      state.inFlight = false;
+      if (!!state.desired !== target) {
+        drainDailyToggle(id, state);
+        return;
+      }
+      const current = dailyTasks.find((item) => item.id === id);
+      if (current) {
+        Object.assign(current, JSON.parse(JSON.stringify(state.confirmedTask)));
+        dailySignature = dailyPayloadSignature({ tasks: dailyTasks, groups: dailyGroups });
+        syncDailyToggleResult(id, current);
+      }
+      finishDailyToggleState(id, state);
+      toast(error.message);
+    });
   }
   function toggleDailyTask(id) {
     const task = dailyTasks.find((item) => item.id === id);
     if (!task) return;
-    const want = !task.doneToday;
+    let state = dailyToggleStates.get(id);
+    if (!state) {
+      state = {
+        confirmedTask: JSON.parse(JSON.stringify(task)),
+        desired: !!task.doneToday,
+        inFlight: false,
+      };
+      dailyToggleStates.set(id, state);
+    }
+    const want = !state.desired;
+    state.desired = want;
     const prevTotalDays = Math.max(0, Number(task.totalDays) || 0);
     const targetDays = dailyGoalState(task).target;
     task.doneToday = want;
@@ -3609,43 +4013,17 @@
     updateDailyFoot();
     pulseDailyFoot();
     renderDailyHistory();
-    dailyCelebrationCheck({
-      waitForGoal: want && targetDays > 0,
-      waitForMilestone: want && crossedMilestones.length > 0,
-    });
-    maybeAutoCollapseCompletedGroup(id);
-    post('/api/daily-toggle', { id: id, done: want })
-      .then((json) => {
-        applyDailyPayload(json);
-        const fresh = dailyTasks.find((item) => item.id === id);
-        if (fresh) {
-          if (!dailyClearing) refreshDailyRowStats(fresh);
-          refreshDailyDetailGoal(fresh);
-          refreshDailyGroupProgress(fresh.groupId);
-        }
-        renderDailyHistory();
-        renderTaskOptions();
-      })
-      .catch((error) => {
-        task.doneToday = !want;
-        task.doneDates = prevDates;
-        task.totalDays = prevTotalDays;
-        setRowDone(row, !want);
-        refreshDailyRowStats(task);
-        refreshDailyDetailGoal(task);
-        refreshDailyGroupProgress(task.groupId);
-        updateDailyFoot();
-        pulseDailyFoot();
-        hideDailyCelebrate();
-        renderDaily();
-        toast(error.message);
-      });
+    if (want && allDailyDone()) dailyCelebrateReturnId = id;
+    dailyCelebrationCheck();
+    if (row) row.classList.add('is-syncing');
+    drainDailyToggle(id, state);
   }
   function completeDailyTask(id) {
     return post('/api/daily-toggle', { id: id, done: true }).then((json) => {
       applyDailyPayload(json);
       dailyLoaded = true;
-      if (dailyOpen && !dailyClearing) renderDaily();
+      if (allDailyDone()) dailyCelebrateReturnId = id;
+      if (dailyLoaded) renderDaily({ celebrate: true });
       renderTaskOptions();
     });
   }
@@ -3654,7 +4032,7 @@
     return post('/api/daily-add-minutes', { id: id, minutes: minutes })
       .then((json) => {
         applyDailyPayload(json);
-        if (dailyLoaded && !dailyClearing) renderDaily();
+        if (dailyLoaded) renderDaily();
         renderTaskOptions();
       })
       .catch(() => {});
@@ -3922,9 +4300,8 @@
     }
     if (action.dataset.action === 'focus-help-close') toggleHelp(false);
     if (action.dataset.action === 'focus-zen-enter') toggleZen();
-    if (action.dataset.action === 'daily-toggle') toggleDaily();
-    if (action.dataset.action === 'daily-close') toggleDaily(false);
-    if (action.dataset.action === 'daily-peek') dailyPeekList();
+    if (action.dataset.action === 'daily-review-today') { reviewDailyCelebration(); return; }
+    if (action.dataset.action === 'daily-compose-toggle') toggleDailyComposer();
     if (action.dataset.action === 'daily-history-close') closeDailyHistory();
     if (action.dataset.action === 'daily-history-prev') moveDailyHistoryMonth(-1);
     if (action.dataset.action === 'daily-history-next') moveDailyHistoryMonth(1);
@@ -3948,7 +4325,7 @@
       if (task && bindTask(task.id, task.name || '', 'daily')) {
         renderTaskOptions();
         syncDisplay();
-        renderDailyDetail();
+        showTimerView({ persist: false, animate: false });
       }
     }
     if (action.dataset.action === 'daily-detail-edit' && dailyDetailTaskId) {
@@ -4098,31 +4475,14 @@
     const typing = isTypingTarget(target);
     const dailyDetailShell = getDailyDetailShell();
     const dailyDetailOpen = !!dailyDetailTaskId || !!dailyDetailShell;
-    if (event.key === 'Tab' && !event.ctrlKey && !event.altKey && !event.metaKey && !zenActive) {
-      const blocked = (helpPop && !helpPop.hidden) || (settingsPop && !settingsPop.hidden)
-        || (sessionEditor && !sessionEditor.hidden) || (wrapupEl && !wrapupEl.hidden) || dailyDetailOpen;
-      if (dailyDetailOpen) {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!dailyDetailShell || !dailyDetailShell.classList.contains('is-closing')) closeDailyDetail();
-        return;
-      }
-      if (!blocked && dailyOpen) {
-        event.preventDefault();
-        event.stopPropagation();
-        toggleDaily(false);
-        return;
-      }
-      if (typing) return;
-      if (!blocked) {
-        event.preventDefault();
-        event.stopPropagation();
-        toggleDaily();
-        return;
-      }
+    if (event.key === 'Escape' && dailyComposerOpen && dailyComposerEl && dailyComposerEl.contains(target)) {
+      event.preventDefault();
+      event.stopPropagation();
+      closeDailyComposer({ focus: true });
+      return;
     }
     if (typing) return;
-    if (event.key === '?') {
+    if (viewMode === 'timer' && event.key === '?') {
       event.preventDefault();
       if (!zenActive) toggleHelp();
       return;
@@ -4142,15 +4502,17 @@
       if (dailyGroupEditId) { event.preventDefault(); closeDailyGroupEdit(); return; }
       if (dailyConfirmDeleteId) { event.preventDefault(); cancelDeleteDaily(); return; }
       if (dailyEditId) { event.preventDefault(); closeDailyEdit(); return; }
-      if (dailyOpen) { event.preventDefault(); toggleDaily(false); return; }
+      if (dailyComposerOpen) { event.preventDefault(); closeDailyComposer({ focus: true }); return; }
     }
     const overlayOpen = (helpPop && !helpPop.hidden) || (settingsPop && !settingsPop.hidden)
       || (sessionEditor && !sessionEditor.hidden) || dailyDetailOpen;
-    if (event.code === 'Space' && !overlayOpen && !pendingSession && !(wrapupEl && !wrapupEl.hidden)) {
+    if (viewMode === 'timer' && event.code === 'Space'
+      && !overlayOpen && !pendingSession && !(wrapupEl && !wrapupEl.hidden)) {
       event.preventDefault();
       if (!running || paused) start(); else pause();
     }
-    if ((event.key === 'z' || event.key === 'Z') && !overlayOpen && running && !pendingSession) {
+    if (viewMode === 'timer' && (event.key === 'z' || event.key === 'Z')
+      && !overlayOpen && running && !pendingSession) {
       event.preventDefault();
       toggleZen();
     }
@@ -4175,20 +4537,84 @@
   try { boundTaskId = localStorage.getItem(TASK_KEY) || ''; } catch (e) {}
   try { boundKind = boundTaskId ? (localStorage.getItem(KIND_KEY) || 'study') : ''; } catch (e) {}
   restoreRuntime();
+  if (root.dataset.pendingForceTimer === '1' || sessionLocksView()) viewMode = 'timer';
   syncModeUI();
   syncDisplay();
-  syncDailyPanelFocusability();
+  root.classList.toggle('focus-view-daily', viewMode === 'daily');
+  syncViewAccessibility();
 
-  window.CanvasFocus = {
+  function prepareFocusActivation(options) {
+    const opts = options || {};
+    focusActivationSeq += 1;
+    focusPrepared = true;
+    focusLifecycleActive = false;
+    dailyRevealKey = '';
+    clearViewTransition(true);
+    const preferred = opts.forceTimer || sessionLocksView() ? 'timer' : readViewMode();
+    commitViewMode(preferred, { persist: false, load: false, reveal: false });
+    if (preferred === 'daily' && !dailyLoaded) setDailyLoading(true);
+    return preferred;
+  }
+  function deactivateFocusView() {
+    focusLifecycleActive = false;
+    focusPrepared = false;
+    focusActivationSeq += 1;
+    clearViewTransition(true);
+    window.clearTimeout(dailyRevealTimer);
+    window.clearTimeout(dailyDataRevealTimer);
+    window.clearTimeout(dailyCelebrateMotionTimer);
+    window.clearTimeout(dailyCelebrateHideTimer);
+    window.clearTimeout(dailyCelebrateFocusTimer);
+    dailyRevealTimer = 0;
+    dailyDataRevealTimer = 0;
+    dailyCelebrateMotionTimer = 0;
+    dailyCelebrateHideTimer = 0;
+    dailyCelebrateFocusTimer = 0;
+    dailyCelebrateGeneration += 1;
+    dailyRevealWaitingForData = false;
+    dailyRevealKey = '';
+    if (dailyRoot) dailyRoot.classList.remove('is-revealing', 'is-data-revealing');
+    if (dailyCelebrateEl) {
+      dailyCelebrateEl.classList.remove('is-entering', 'is-leaving', 'is-static');
+      if (allDailyDone() && !dailyReviewedToday()) {
+        dailyCelebrateEl.classList.add('is-visible');
+        commitDailyCelebratePhase('visible');
+      } else {
+        dailyCelebrateEl.classList.remove('is-visible');
+        commitDailyCelebratePhase('hidden');
+      }
+    }
+    cancelDailyRead();
+    endDailyPointerDrag(null, false);
+    closeDailyHistory();
+    closeDailyDetail({ restore: false, instant: true });
+  }
+
+  const canvasFocusApi = {
+    prepareActivate(options) {
+      return prepareFocusActivation(options);
+    },
     activate() {
+      if (!focusPrepared) prepareFocusActivation();
+      focusPrepared = false;
+      focusLifecycleActive = true;
+      const activationId = focusActivationSeq;
       footprintDay = todayStr();
       footprintSessionId = '';
       loadTasks();   // 任务下拉框每次重读，和学习页实时同步（任务联动敏感，不缓存）
-      loadDaily();   // 每日任务每次重读：跨天重置要靠它，开销也小
+      const hadDaily = dailyLoaded;
+      const dailyEntranceKey = 'activation-' + activationId;
+      if (viewMode === 'daily') {
+        // 首载先让页首只入场一次，并保持同一 generation；数据到达后新插入的卡片
+        // 在同一个 is-revealing 周期内接上错峰，不再重放页首或整页动画。
+        replayDailyViewEntrance(dailyEntranceKey, { waitForData: !hadDaily });
+      }
+      loadDaily({ reveal: !hadDaily, revealKey: dailyEntranceKey });
+      // 每日任务每次静默重读以处理跨天重置；签名没变化时不重建、不重播动画。
       if (!loadedSessions) loadSessions(); else renderFootprint();
       syncDisplay();
       handleExpiredRestore();
-      requestAnimationFrame(replayFocusEntrance);
+      if (viewMode === 'timer') requestAnimationFrame(replayFocusEntrance);
       if (helpBtn) {
         try {
           if (localStorage.getItem('canvas:focusHelpSeen') !== '1') {
@@ -4198,7 +4624,9 @@
         } catch (e) {}
       }
     },
+    deactivate: deactivateFocusView,
     prepareTask(id, title) {
+      showTimerView({ persist: false, animate: false });
       if (!bindTask(id, title)) return false;
       loadTasks().then(() => {
         if (taskSelect) taskSelect.value = boundTaskId;
@@ -4207,6 +4635,7 @@
       return true;
     },
     showDay(day, sessionId) {
+      showTimerView({ persist: false, animate: false });
       footprintDay = /^\d{4}-\d{2}-\d{2}$/.test(String(day || '')) ? String(day) : todayStr();
       footprintSessionId = String(sessionId || '');
       return loadSessions().then(() => {
@@ -4216,5 +4645,13 @@
         if (footprintSessionId) openSessionEditor(footprintSessionId);
       });
     },
+    toggleMode: toggleViewMode,
+    showTimer(options) { return showTimerView(options); },
+    getViewMode() { return viewMode; },
+    isViewLocked: sessionLocksView,
   };
+  preloadFocusView().finally(() => {
+    window.CanvasFocus = canvasFocusApi;
+    document.dispatchEvent(new CustomEvent('canvasfocus:ready'));
+  });
 })();

--- a/assets/i18n.js
+++ b/assets/i18n.js
@@ -67,10 +67,10 @@
     '选中任务按 G 加入，或按 F 进入今日专注': 'Select a task and press G, or press F to enter Focus.',
     '今天的任务，全部完成。': 'Everything for today is complete.',
     '给自己一个停顿。明天的事，明天再说。': 'Take a breath. Tomorrow can wait until tomorrow.',
-    '还没有每日任务 · 在下面加一件想每天坚持的事': 'No daily tasks yet · add one small thing to repeat each day.',
+    '还没有每日任务 · 点右上角“＋”加一件想每天坚持的事': 'No daily tasks yet · use “+” to add one small thing to repeat each day.',
     '未命名任务': 'Untitled task', '未命名分组': 'Untitled group', '（不分组）': '(No group)',
     '子分组': 'Subgroup', '在此加任务': 'Add task here', '空': 'Empty',
-    '已绑定本段': 'Bound to session', '设为本段专注': 'Focus on this',
+    '已绑定本段': 'Bound to session', '设为本段专注': 'Focus on this', '添加分组': 'Add group',
     '取消今日打卡': 'Undo today', '今日打卡': 'Check in today', '还没有历史打卡': 'No check-ins yet',
 
     '复习卡片': 'Review Cards', '待复习': 'Due', '今日复习': 'Reviewed today', '更新': 'Refresh',
@@ -185,7 +185,6 @@
     '这一段准备完成什么？（可选）': 'What will you accomplish this session? (optional)',
     '绑定学习任务': 'Link a study task', '计时模式': 'Timer mode',
     '双击修改专注时长': 'Double-click to change focus length',
-    '每日任务（Tab 开合）': 'Daily tasks (Tab to toggle)',
     '开始或暂停': 'Start or pause', '开始': 'Start', '暂停': 'Pause', '完成本段': 'Finish session',
     '退出深度专注': 'Exit deep focus', '深度专注': 'Deep focus', '今日足迹': 'Today’s trail',
     '今天还没有专注记录 · 开始第一段吧': 'No focus sessions yet · begin the first one.',
@@ -201,14 +200,33 @@
     '修改番茄钟的专注分钟数；运行中不可修改。': 'Change focus minutes before the timer starts.',
     '选择任务': 'Choose a task', '这一段会计入所选的学习任务或每日任务。': 'This session will count toward the selected study or daily task.',
     '每日任务': 'Daily tasks', '深度专注': 'Deep focus',
+    '每日任务视图': 'Daily tasks view', '新增每日任务或分组': 'Add a daily task or group',
+    '再次点击左侧“专”进入完整清单：勾选完成、管理分组，并回看累计天数与专注分钟。': 'Select Focus again in the left spine to open the full list, manage groups, and review check-ins and focus minutes.',
     '运行时点 ⛶ 或按 Z 进入全屏极简，Esc 退出。': 'While running, select ⛶ or press Z for a minimal full-screen view. Press Esc to leave.',
     '学习页负责安排，专注页负责执行，日历负责回看。': 'Plan in Study, do the work in Focus, and look back in Calendar.',
-    '查看今日清单': 'View today’s list', '今天的每日任务都做完了': 'All daily tasks are complete.',
+    '今日清单已全部完成': "Today's list is complete.", '回顾今日': 'Review today',
     '正在做': 'Now doing', '自由专注': 'Open focus', '＋ 为这一段写个目标': '+ Add an intention',
     '继续': 'Continue', '跳过休息': 'Skip break', '保存并完成这件每日任务': 'Save & complete daily task',
     '本段将计入': 'This session counts toward',
 
     '年度足迹': 'Annual Activity', '完成': 'Completed', '静': 'Quiet', '丰': 'Full',
+    '画布星图': 'Canvas Constellation', '本月画布时间': 'Canvas time this month',
+    '累计画布时间': 'Total canvas time', '活跃画布': 'Active canvases',
+    '连续活跃': 'Active streak', '历史记录': 'Historical record',
+    '历史时长无法还原': 'Historical time unavailable', '修改': 'Edited',
+    '不足 1 分钟': 'Under 1 min',
+    '画布使用时间星图': 'Canvas time constellation',
+    '使用过的画布，会在这里连成一片星图。': 'Used canvases gather here as a constellation.',
+    '年度足迹与画布活跃': 'Annual activity and canvas usage',
+    '画布时间统计': 'Canvas time summary', '新建': 'Created',
+    '最长连续': 'Longest streak', '当年画布时间': 'Canvas time this year',
+    '悬停回望，点击展开当天画布': 'Hover to look back; select a day to open its canvases.',
+    '这一天还没有画布使用记录。': 'No canvas activity was recorded this day.',
+    '今天还没有打开画布。': 'No canvas has been opened today.',
+    '有历史画布记录，时长无法还原': 'Historical canvas record; time unavailable',
+    '未使用画布': 'No canvas use', '未命名画布': 'Untitled canvas',
+    '打开画布': 'Open canvas', '这里会慢慢长出你的节奏。': 'Your rhythm will gradually take shape here.',
+    '重新统计一年活跃热力图（画布计时、完成任务或专注后想立刻看到，点这里）': 'Refresh annual activity after canvas time, completed work, or focus changes.',
     '足迹浓度从静到丰': 'Activity intensity from quiet to full', '热力图查看': 'Activity view',
     '足迹星图': 'Activity Constellation', '最近完成': 'Recent Completions',
     '活跃统计': 'Activity summary', '专注时间统计': 'Focus summary',
@@ -737,11 +755,10 @@
     '建立分组后可命名、折叠并整体移动': 'Name, collapse, and move the group as a whole',
     '可以把空白选区变成一个盒子': 'Turn an empty selection into a box',
 
-    // ── 专注页 · 每日任务侧栏 ──
+    // ── 专注页 · 每日任务独立视图 ──
     '添加一件今天想坚持的事…': 'Add one thing to repeat today…',
     '新增每日任务': 'Add daily task',
     '添加每日任务': 'Add daily task',
-    '收起每日任务（Tab / Esc）': 'Close daily tasks (Tab / Esc)',
     '新增类型': 'Add type',
     '新建分组名称…': 'New group name…',
     '＋ 子分组': '+ Subgroup',
@@ -813,11 +830,11 @@
     '本段完成': 'Session complete',
     '可选：留下结果、进度或下一步。': 'Optional: record outcomes, progress, or next steps.',
     '请先完成或重置当前专注段': 'Please finish or reset the current session first.',
+    '请先完成收尾或重置当前专注段，再查看每日任务': 'Finish the wrap-up or reset the current session before opening daily tasks.',
 
     // ── 专注页 · 设置 / 帮助 / 提示 ──
     '重新读取任务/每日/记录（平时翻进来用上次结果；在别处改了，点这里才更新）': 'Refresh tasks, daily items, and records. (Uses cached data; click after making changes elsewhere.)',
     '进入深度专注（Z）': 'Enter deep focus (Z)',
-    '按 Tab 划出右侧清单：勾选完成、累计天数与专注分钟，全部完成有庆祝。': 'Press Tab to open the side panel: check off tasks, track streaks and focus minutes. Celebrate when all done.',
     '结束收尾': 'Wrap up',
     '点击圆点可查看、修改或删除一段记录。': 'Click a dot to view, edit, or delete a session.',
     '删除这段专注记录？当天与长期统计会同步扣除。': 'Delete this session? Daily and long-term stats will be updated accordingly.',
@@ -924,6 +941,15 @@
       const days = { 日: 'Sun', 一: 'Mon', 二: 'Tue', 三: 'Wed', 四: 'Thu', 五: 'Fri', 六: 'Sat' };
       return `${days[match[3]]} · ${months[Number(match[1]) - 1]} ${Number(match[2])} · ${EN[match[4]] || translateDynamic(match[4])}`;
     }
+    match = source.match(/^(\d{1,2})\s*月\s*(\d{1,2})\s*日\s*·\s*周([日一二三四五六])\s*·\s*(画布\s*.+|有历史画布记录，时长无法还原|未使用画布)$/);
+    if (match) {
+      const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+      const days = { 日: 'Sun', 一: 'Mon', 二: 'Tue', 三: 'Wed', 四: 'Thu', 五: 'Fri', 六: 'Sat' };
+      const status = match[4].startsWith('画布 ')
+        ? `Canvas ${EN[match[4].slice(3)] || translateDynamic(match[4].slice(3))}`
+        : (EN[match[4]] || match[4]);
+      return `${days[match[3]]} · ${months[Number(match[1]) - 1]} ${Number(match[2])} · ${status}`;
+    }
     match = source.match(/^(\d{1,2})\s*月$/);
     if (match) {
       const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -937,6 +963,9 @@
     if (match) return `${match[1]} sessions · ${EN[match[2]] || translateDynamic(match[2])}`;
     match = source.match(/^共\s*(\d+)\s*段专注$/);
     if (match) return `${match[1]} focus ${match[1] === '1' ? 'session' : 'sessions'}`;
+    match = source.match(/^使用\s*(\d+)\s*张画布(?:\s*·\s*(.+))?$/);
+    if (match) return `${match[1]} ${match[1] === '1' ? 'canvas' : 'canvases'} used`
+      + (match[2] ? ` · ${EN[match[2]] || translateDynamic(match[2])}` : '');
     match = source.match(/^(\d+)\s*分(?:钟)?$/);
     if (match) return `${match[1]} min`;
     match = source.match(/^(\d+(?:\.\d+)?)\s*小时(?:\s*(\d+)\s*分)?$/);
@@ -947,8 +976,12 @@
     if (match) return `View ${match[1]}`;
     match = source.match(/^(\d{4})\s*年逐日已完成任务热力图$/);
     if (match) return `Daily completed-work activity for ${match[1]}`;
+    match = source.match(/^(\d{4})\s*年逐日画布使用时长热力图$/);
+    if (match) return `Daily canvas time for ${match[1]}`;
+    match = source.match(/^(\d{4})\s*年逐日专注时长热力图$/);
+    if (match) return `Daily focus time for ${match[1]}`;
     match = source.match(/^(\d+)\s*天$/);
-    if (match) return `${match[1]} days`;
+    if (match) return `${match[1]} ${match[1] === '1' ? 'day' : 'days'}`;
     match = source.match(/^自动保存到\s*(.+)$/);
     if (match) return `Autosaved to ${match[1]}`;
     match = source.match(/^应用(.+)并整理$/);
@@ -1045,12 +1078,23 @@
     if (match) return `${match[1]} days total`;
     match = source.match(/^累计\s*(\d+)\s*分$/);
     if (match) return `${match[1]} min total`;
+    match = source.match(/^累计不足\s*1\s*分钟$/);
+    if (match) return 'Under 1 min total';
+    match = source.match(/^累计\s*(\d+)\s*分钟$/);
+    if (match) return `${match[1]} min total`;
+    match = source.match(/^累计\s*(\d+)\s*小时(?:\s*(\d+)\s*分)?$/);
+    if (match) return `${match[1]} hr${match[2] ? ` ${match[2]} min` : ''} total`;
     match = source.match(/^今天\s*(\d+)\s*分$/);
     if (match) return `${match[1]} min today`;
     match = source.match(/^累计\s*(\d+)\s*\/\s*(\d+)\s*天\s*·\s*已达成$/);
     if (match) return `${match[1]} / ${match[2]} days total · goal met`;
     match = source.match(/^累计\s*(\d+)\s*\/\s*(\d+)\s*天$/);
     if (match) return `${match[1]} / ${match[2]} days total`;
+    match = source.match(/^今天做完了\s*(\d+)\s*件事(?:\s*·\s*专注\s*(\d+)\s*分钟)?$/);
+    if (match) {
+      const noun = match[1] === '1' ? 'thing' : 'things';
+      return `Finished ${match[1]} ${noun} today${match[2] ? ` · ${match[2]} min focused` : ''}`;
+    }
     match = source.match(/^(\d+)\s*件全部完成\s*·\s*专注\s*(\d+)\s*分钟\s*·\s*明天见$/);
     if (match) return `${match[1]} all complete · ${match[2]} min focused · See you tomorrow`;
     match = source.match(/^(\d+)\s*件全部完成\s*·\s*明天见$/);

--- a/assets/index.html
+++ b/assets/index.html
@@ -28,6 +28,28 @@
     html { background: #fbfbfa; }
     html[data-start-theme="dark"] { background: #111213; color-scheme: dark; }
   </style>
+  <link rel="preload" href="focus.js" as="script">
+  <script>
+    // 专注页位于脚本队列末端。页面解析时就并行读取其轻量数据，第一次翻页与后续翻页共用缓存。
+    (function () {
+      function preloadJson(path) {
+        return fetch(path, { credentials: 'same-origin' }).then(function (response) {
+          if (!response.ok) throw new Error('preload failed');
+          return response.json();
+        }).then(function (json) {
+          return { ok: true, json: json };
+        }, function () {
+          return { ok: false, json: null };
+        });
+      }
+      window.RelatumBoot = window.RelatumBoot || {};
+      window.RelatumBoot.focus = {
+        daily: preloadJson('/api/daily'),
+        sessions: preloadJson('/api/focus'),
+        study: preloadJson('/api/study'),
+      };
+    })();
+  </script>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body class="start-page">
@@ -324,7 +346,7 @@
 
       <!-- 活跃热力图 · 独立前置页（与学习页之间可翻页；内容由 study.js 渲染）-->
       <section class="cadence-embedded" data-role="cadence-view" aria-label="活跃热力图页">
-        <section class="study-cadence" data-role="study-cadence" aria-label="已完成任务 · 一年活跃"></section>
+        <section class="study-cadence" data-role="study-cadence" aria-label="年度足迹与画布活跃"></section>
       </section>
 
       <!-- 速记 · 便签墙独立前置页（活跃更左一格；便签由 notes.js 创建/渲染/存盘）。
@@ -693,7 +715,7 @@
 
       <!-- 专注钟 · 当下在做的前置页：计时 + 目标成果 + 今日足迹 -->
       <section class="focus-embedded" data-role="focus-view" aria-label="专注钟页">
-        <div class="focus-shell">
+        <div class="focus-shell focus-timer-view" data-role="focus-timer-view">
           <header class="focus-head">
             <div>
               <p class="study-eyebrow">FOCUS</p>
@@ -854,50 +876,69 @@
             <dl>
               <div><dt>双击时间</dt><dd>修改番茄钟的专注分钟数；运行中不可修改。</dd></div>
               <div><dt>选择任务</dt><dd>这一段会计入所选的学习任务或每日任务。</dd></div>
-              <div><dt>每日任务</dt><dd>按 Tab 划出右侧清单：勾选完成、累计天数与专注分钟，全部完成有庆祝。</dd></div>
+              <div><dt>每日任务</dt><dd>再次点击左侧“专”进入完整清单：勾选完成、管理分组，并回看累计天数与专注分钟。</dd></div>
               <div><dt>本段目标</dt><dd>开始前写下这一段准备完成什么；运行中也可点座舱目标行随时补改。</dd></div>
               <div><dt>结束收尾</dt><dd>补一句实际成果，再继续、收工或明确完成任务。</dd></div>
               <div><dt>今日足迹</dt><dd>点击圆点可查看、修改或删除一段记录。</dd></div>
               <div><dt>深度专注</dt><dd>运行时点 ⛶ 或按 Z 进入全屏极简，Esc 退出。</dd></div>
             </dl>
-            <p class="focus-help-shortcuts"><kbd>Space</kbd> 开始 / 暂停　<kbd>Tab</kbd> 每日任务　<kbd>Z</kbd> 深度专注　<kbd>?</kbd> 帮助　<kbd>Esc</kbd> 关闭 / 退出</p>
+            <p class="focus-help-shortcuts"><kbd>Space</kbd> 开始 / 暂停　<kbd>Z</kbd> 深度专注　<kbd>?</kbd> 帮助　<kbd>Esc</kbd> 关闭 / 退出</p>
             <footer>学习页负责安排，专注页负责执行，日历负责回看。</footer>
           </aside>
         </div>
 
-        <!-- 每日任务侧栏：习惯清单，默认收起，Tab / 右侧把手划出；与学习任务、.canvas 完全解耦 -->
-        <button type="button" class="focus-daily-handle" data-action="daily-toggle"
-          aria-label="每日任务（Tab 开合）" aria-expanded="false">
-          <span class="focus-daily-handle-text">每日任务</span>
-          <kbd>Tab</kbd>
-        </button>
-        <aside class="focus-daily" data-role="focus-daily" aria-label="每日任务" hidden>
-          <header class="focus-daily-head">
-            <div><p class="study-eyebrow">DAILY</p><h2>每日任务</h2></div>
-            <button type="button" class="study-icon-button" data-action="daily-close"
-              aria-label="收起每日任务（Tab / Esc）">×</button>
-          </header>
-          <div class="focus-daily-list" data-role="focus-daily-list"></div>
-          <div class="focus-daily-compose" data-role="focus-daily-compose">
-            <div class="focus-daily-compose-modes" role="group" aria-label="新增类型">
-              <button type="button" class="is-active" data-role="daily-compose-task" aria-pressed="true">任务</button>
-              <button type="button" data-role="daily-compose-group" aria-pressed="false">分组</button>
+        <!-- 每日任务独立视图：再次点击左侧“专”与专注钟切换；数据仍来自 data/daily.json。 -->
+        <section class="focus-daily focus-daily-view" data-role="focus-daily" aria-label="每日任务视图" hidden>
+          <div class="focus-daily-scroll" data-role="focus-daily-scroll" tabindex="-1">
+            <header class="focus-daily-head">
+              <div>
+                <p class="study-eyebrow">DAILY</p>
+                <h1>每日任务 <span data-role="focus-daily-count">0</span></h1>
+              </div>
+              <button type="button" class="focus-daily-create" data-action="daily-compose-toggle"
+                aria-label="新增每日任务或分组" aria-expanded="false">＋</button>
+            </header>
+            <div class="focus-daily-content">
+              <div class="focus-daily-skeleton" data-role="focus-daily-skeleton" aria-hidden="true" hidden>
+                <span></span><span></span><span></span>
+              </div>
+              <div class="focus-daily-list" data-role="focus-daily-list"></div>
             </div>
-            <button type="button" class="focus-daily-compose-target" data-role="daily-compose-target" hidden></button>
+            <div class="focus-daily-composer" data-role="focus-daily-composer" hidden>
+              <div class="focus-daily-compose" data-role="focus-daily-compose">
+                <div class="focus-daily-compose-modes" role="group" aria-label="新增类型">
+                  <button type="button" class="is-active" data-role="daily-compose-task" aria-pressed="true">任务</button>
+                  <button type="button" data-role="daily-compose-group" aria-pressed="false">分组</button>
+                </div>
+                <button type="button" class="focus-daily-compose-target" data-role="daily-compose-target" hidden></button>
+              </div>
+              <form class="focus-daily-add" data-role="focus-daily-add">
+                <input type="text" maxlength="80" data-role="focus-daily-input"
+                  placeholder="添加一件今天想坚持的事…" aria-label="新增每日任务">
+                <button type="submit" class="focus-daily-add-btn" aria-label="添加每日任务">＋</button>
+              </form>
+            </div>
+            <p class="focus-daily-foot" data-role="focus-daily-foot"></p>
           </div>
-          <form class="focus-daily-add" data-role="focus-daily-add">
-            <input type="text" maxlength="80" data-role="focus-daily-input"
-              placeholder="添加一件今天想坚持的事…" aria-label="新增每日任务">
-            <button type="submit" class="focus-daily-add-btn" aria-label="添加每日任务">＋</button>
-          </form>
-          <p class="focus-daily-foot" data-role="focus-daily-foot"></p>
-          <div class="focus-daily-celebrate" data-role="focus-daily-celebrate" hidden aria-live="polite">
-            <span class="focus-daily-celebrate-burst" aria-hidden="true"></span>
-            <strong>今天的每日任务都做完了</strong>
-            <span class="focus-daily-celebrate-sub" data-role="focus-daily-celebrate-sub"></span>
-            <button type="button" class="focus-daily-celebrate-peek" data-action="daily-peek">查看今日清单</button>
+          <div class="focus-daily-celebrate" data-role="focus-daily-celebrate"
+            data-phase="hidden" aria-hidden="true" aria-labelledby="focus-daily-celebrate-title">
+            <div class="focus-daily-celebrate-inner">
+              <div class="focus-daily-star-gather" aria-hidden="true">
+                <span class="focus-daily-star-halo"></span>
+                <i class="focus-daily-star-dot dot-far-left"></i>
+                <i class="focus-daily-star-dot dot-near-left"></i>
+                <span class="focus-daily-star-main"></span>
+                <i class="focus-daily-star-dot dot-near-right"></i>
+                <i class="focus-daily-star-dot dot-far-right"></i>
+              </div>
+              <div class="focus-daily-celebrate-copy" aria-live="polite" aria-atomic="true">
+                <strong id="focus-daily-celebrate-title">今日清单已全部完成</strong>
+                <span class="focus-daily-celebrate-sub" data-role="focus-daily-celebrate-sub"></span>
+              </div>
+              <button type="button" class="focus-daily-review-today" data-action="daily-review-today">回顾今日</button>
+            </div>
           </div>
-        </aside>
+        </section>
       </section>
     </section>
   </main>

--- a/assets/start.js
+++ b/assets/start.js
@@ -67,6 +67,8 @@
   let calendarActive = false;  // 日历与日记前置页（在复习与速记之间）是否展开
   let reviewActive = false;    // 复习卡片前置页（最左一格）是否展开
   let focusActive = false;     // 专注钟前置页（学习更右一格、紧邻书页）是否展开
+  let pendingFocusActivation = null;
+  let pendingFocusReadyActions = [];
   let specialPagesHidden = false; // 「隐藏特殊页」开启：书脊只留普通书页，6 张前置页既不显示也不可翻入
   const FAVORITES_PAGE = '__favorites__';
   const INBOX_PAGE = '__inbox__';
@@ -1068,6 +1070,16 @@
     // 'cadence'（活跃热力图页）与 'study' 共用同一套书页舞台布局壳，只用 cadence-active 切换浮层，
     // 这样 [data-start-state="study"] 那批布局 CSS 仍然生效，无需为 cadence 再写一套。
     const previous = bookView ? (bookView.dataset.viewName || '') : '';
+    if (name !== 'focus') {
+      pendingFocusActivation = null;
+      pendingFocusReadyActions = [];
+      const focusRoot = document.querySelector('.focus-embedded');
+      if (focusRoot) delete focusRoot.dataset.pendingForceTimer;
+    }
+    if (previous === 'focus' && name !== 'focus'
+      && window.CanvasFocus && typeof window.CanvasFocus.deactivate === 'function') {
+      window.CanvasFocus.deactivate();
+    }
     const layout = (name === 'cadence' || name === 'notes' || name === 'calendar'
       || name === 'review' || name === 'focus') ? 'study' : name;
     main.dataset.state = layout;
@@ -1464,7 +1476,7 @@
     if (bookStage) bookStage.scrollTop = 0;
   }
 
-  function setFocusActive(active) {
+  function setFocusActive(active, options) {
     focusActive = !!active;
     if (focusActive) {
       studyActive = false;
@@ -1474,13 +1486,52 @@
       reviewActive = false;
       cancelPendingDelete();
       closeContextMenu();
-      showView('focus');
-      if (window.CanvasFocus && window.CanvasFocus.activate) window.CanvasFocus.activate();
+      if (window.CanvasFocus && typeof window.CanvasFocus.prepareActivate === 'function') {
+        pendingFocusActivation = null;
+        pendingFocusReadyActions = [];
+        window.CanvasFocus.prepareActivate(options || {});
+        const focusRoot = document.querySelector('.focus-embedded');
+        if (focusRoot) delete focusRoot.dataset.pendingForceTimer;
+        showView('focus');
+        if (window.CanvasFocus.activate) window.CanvasFocus.activate();
+        return;
+      }
+      pendingFocusActivation = { options: Object.assign({}, options || {}) };
+      pendingFocusReadyActions = [];
+      const focusRoot = document.querySelector('.focus-embedded');
+      if (focusRoot) focusRoot.dataset.pendingForceTimer = options && options.forceTimer ? '1' : '0';
       return;
     }
     showView(listViewName());
     if (bookStage) bookStage.scrollTop = 0;
   }
+
+  function runWhenCanvasFocusReady(action) {
+    if (typeof action !== 'function' || !focusActive) return;
+    if (window.CanvasFocus) {
+      action(window.CanvasFocus);
+      return;
+    }
+    pendingFocusReadyActions.push(action);
+  }
+
+  function finishPendingFocusActivation() {
+    if (!focusActive || !pendingFocusActivation || !window.CanvasFocus) return;
+    const pending = pendingFocusActivation;
+    const actions = pendingFocusReadyActions.slice();
+    pendingFocusActivation = null;
+    pendingFocusReadyActions = [];
+    const focusRoot = document.querySelector('.focus-embedded');
+    if (focusRoot) delete focusRoot.dataset.pendingForceTimer;
+    if (typeof window.CanvasFocus.prepareActivate === 'function') {
+      window.CanvasFocus.prepareActivate(pending.options || {});
+    }
+    showView('focus');
+    if (typeof window.CanvasFocus.activate === 'function') window.CanvasFocus.activate();
+    actions.forEach((action) => action(window.CanvasFocus));
+  }
+
+  document.addEventListener('canvasfocus:ready', finishPendingFocusActivation);
 
   function gotoEditor(path, sourceItem, fresh) {
     if (document.body.classList.contains('canvas-route-leaving')) return;
@@ -1540,6 +1591,17 @@
     return parts.join(' · ');
   }
 
+  function formatCanvasActivity(sec) {
+    sec = Math.max(0, Number(sec) || 0);
+    if (!sec) return '';
+    if (sec < 60) return '累计不足 1 分钟';
+    const min = Math.floor(sec / 60);
+    if (min < 60) return '累计 ' + min + ' 分钟';
+    const hours = Math.floor(min / 60);
+    const rest = min % 60;
+    return '累计 ' + hours + ' 小时' + (rest ? ' ' + rest + ' 分' : '');
+  }
+
   function updateFileItemStats(li, f) {
     if (!li || !f) return;
     const missing = f.exists === false;
@@ -1558,6 +1620,18 @@
     }
 
     const meta = li.querySelector('.recent-item-meta');
+    let duration = meta && meta.querySelector('.recent-item-duration');
+    const durationText = formatCanvasActivity(f.canvasActivitySec);
+    if (durationText && meta) {
+      if (!duration) {
+        duration = document.createElement('span');
+        duration.className = 'recent-item-duration';
+        meta.appendChild(duration);
+      }
+      duration.textContent = durationText;
+    } else if (duration) {
+      duration.remove();
+    }
     let stats = meta && meta.querySelector('.recent-item-stats');
     const statsText = formatFileStats(f);
     if (statsText && meta) {
@@ -1570,6 +1644,8 @@
     } else if (stats) {
       stats.remove();
     }
+    // 节点数和文件大小可能稍后异步补回；每次更新后都把累计时长重新放到末尾。
+    if (duration && durationText && meta) meta.appendChild(duration);
   }
 
   async function requestFileStats(paths, requestId) {
@@ -2143,6 +2219,13 @@
       stats.className = 'recent-item-stats';
       stats.textContent = statsText;
       meta.appendChild(stats);
+    }
+    const durationText = formatCanvasActivity(f.canvasActivitySec);
+    if (durationText) {
+      const duration = document.createElement('span');
+      duration.className = 'recent-item-duration';
+      duration.textContent = durationText;
+      meta.appendChild(duration);
     }
     const favorite = document.createElement('button');
     favorite.type = 'button';
@@ -2789,7 +2872,13 @@
     btn.addEventListener('click', () => { setCalendarActive(true); });
   });
   document.querySelectorAll('[data-action="focus-view"]').forEach((btn) => {
-    btn.addEventListener('click', () => { setFocusActive(true); });
+    btn.addEventListener('click', () => {
+      if (focusActive && window.CanvasFocus && typeof window.CanvasFocus.toggleMode === 'function') {
+        window.CanvasFocus.toggleMode();
+      } else {
+        setFocusActive(true);
+      }
+    });
   });
   // 速记归档：把整墙便签里「有名字」的搬进 data/学习归档/<日期>+<N>条速记/，
   // 无名便签随之清空但不归档；归档后刷新活跃页统计。由长按速记图标触发。
@@ -2859,20 +2948,20 @@
     }
     if (view === 'cadence') setCadenceActive(true);
     if (view === 'focus') {
-      setFocusActive(true);
-      if (event.detail.day && window.CanvasFocus && window.CanvasFocus.showDay) {
-        window.CanvasFocus.showDay(event.detail.day, event.detail.sessionId);
-      }
+      setFocusActive(true, { forceTimer: true });
+      runWhenCanvasFocusReady((focus) => {
+        if (event.detail.day && focus.showDay) focus.showDay(event.detail.day, event.detail.sessionId);
+      });
     }
   });
 
   document.addEventListener('focus:prepare', (event) => {
     const detail = event.detail || {};
-    setFocusActive(true);
-    requestAnimationFrame(() => {
-      if (window.CanvasFocus && window.CanvasFocus.prepareTask) {
-        window.CanvasFocus.prepareTask(detail.taskId, detail.taskTitle);
-      }
+    setFocusActive(true, { forceTimer: true });
+    runWhenCanvasFocusReady((focus) => {
+      requestAnimationFrame(() => {
+        if (focus.prepareTask) focus.prepareTask(detail.taskId, detail.taskTitle);
+      });
     });
   });
 

--- a/assets/study-graph.js
+++ b/assets/study-graph.js
@@ -105,6 +105,16 @@
     else if (total >= 1) level = 1;
     return tones[level];
   }
+  function durationLabel(seconds, english) {
+    const min = Math.round(Math.max(0, Number(seconds) || 0) / 60);
+    if (min < 1) return english ? 'under 1 min' : '不足 1 分钟';
+    if (min < 60) return english ? min + ' min' : min + ' 分钟';
+    const hours = Math.floor(min / 60);
+    const rest = min % 60;
+    return english
+      ? hours + ' hr' + (rest ? ' ' + rest + ' min' : '')
+      : hours + ' 小时' + (rest ? ' ' + rest + ' 分' : '');
+  }
   function clipLabel(text, max) {
     const s = String(text || '').replace(/\s+/g, ' ').trim() || (isEnglish() ? 'Untitled' : '未命名');
     return s.length > max ? s.slice(0, max - 1) + '…' : s;
@@ -128,7 +138,8 @@
     const canvas = document.createElement('canvas');
     canvas.className = 'star-canvas';
     canvas.setAttribute('role', 'img');
-    canvas.setAttribute('aria-label', '已完成任务足迹星图');
+    const canvasActivityGraph = !!(graphData && graphData.kind === 'canvas');
+    canvas.setAttribute('aria-label', canvasActivityGraph ? '画布使用时间星图' : '已完成任务足迹星图');
     stage.appendChild(canvas);
     const tooltip = document.createElement('div');
     tooltip.className = 'star-tooltip';
@@ -136,7 +147,9 @@
     stage.appendChild(tooltip);
     const empty = document.createElement('div');
     empty.className = 'star-empty';
-    empty.textContent = '归档过的完成任务，会在这里连成一片星图。';
+    empty.textContent = canvasActivityGraph
+      ? '使用过的画布，会在这里连成一片星图。'
+      : '归档过的完成任务，会在这里连成一片星图。';
     empty.hidden = true;
     stage.appendChild(empty);
     host.appendChild(stage);
@@ -194,11 +207,26 @@
       edges = [];
       const months = (data && Array.isArray(data.months)) ? data.months : [];
       const years = (data && Array.isArray(data.years)) ? data.years : [];
+      const canvasGraph = !!(data && data.kind === 'canvas');
       if (!months.length && !years.length) return;
 
-      const totalAll = years.length
-        ? years.reduce((sum, year) => sum + (year.total || 0), 0)
-        : months.reduce((sum, month) => sum + (month.total || 0), 0);
+      const canvasIds = new Set();
+      if (canvasGraph) {
+        const sourceMonths = years.length
+          ? years.flatMap((year) => Array.isArray(year.months) ? year.months : [])
+          : months;
+        sourceMonths.forEach((month) => (month.named || []).forEach((item) => {
+          canvasIds.add(String(item.id || item.path || item.title || ''));
+        }));
+      }
+      const totalAll = canvasGraph
+        ? canvasIds.size
+        : years.length
+          ? years.reduce((sum, year) => sum + (year.total || 0), 0)
+          : months.reduce((sum, month) => sum + (month.total || 0), 0);
+      const durationAll = years.length
+        ? years.reduce((sum, year) => sum + (year.durationSec || 0), 0)
+        : months.reduce((sum, month) => sum + (month.durationSec || 0), 0);
       const rootColor = theme.rootColor;
       const yearColor = theme.yearColor;
       const taskColor = theme.taskColor;
@@ -206,7 +234,11 @@
       const english = isEnglish();
       const root = {
         tier: 'root', label: english ? 'Me' : '我',
-        tip: english
+        tip: canvasGraph
+          ? (english
+            ? totalAll + ' canvases · ' + durationLabel(durationAll, true)
+            : totalAll + ' 张画布 · ' + durationLabel(durationAll, false))
+          : english
           ? totalAll + ' total · ' + (years.length ? years.length + ' years' : months.length + ' months')
           : '累计 ' + totalAll + ' 件'
             + (years.length ? ' · ' + years.length + ' 年' : ' · ' + months.length + ' 个月'),
@@ -218,21 +250,36 @@
 
       function addMonth(month, parentIndex, rest) {
         const total = month.total || 0;
-        const color = monthTone(total, theme.monthTones);
+        const durationSec = Math.max(0, Number(month.durationSec) || 0);
+        const color = monthTone(canvasGraph ? Math.max(0, Math.ceil(durationSec / 3600)) : total, theme.monthTones);
         const monthNode = {
           tier: 'month', label: monthLabel(month.month),
-          tip: monthLabel(month.month) + (english ? ' · ' + total + ' completed' : ' · 完成 ' + total + ' 项'),
+          tip: canvasGraph
+            ? monthLabel(month.month) + ' · ' + total + (english ? ' canvases · ' : ' 张画布 · ')
+              + durationLabel(durationSec, english)
+            : monthLabel(month.month) + (english ? ' · ' + total + ' completed' : ' · 完成 ' + total + ' 项'),
           color: color, rgb: rgbString(color),
-          r: clamp(8 + total * 1.1, 8, 18), x: 0, y: 0,
+          r: canvasGraph
+            ? clamp(8 + Math.log1p(durationSec / 60) * 1.45, 8, 18)
+            : clamp(8 + total * 1.1, 8, 18), x: 0, y: 0,
         };
         const monthIndex = nodes.push(monthNode) - 1;
         edges.push({ source: parentIndex, target: monthIndex, rest: rest });
 
         (month.named || []).forEach((task) => {
+          const taskSec = Math.max(0, Number(task.durationSec) || 0);
+          const totalTaskSec = Math.max(taskSec, Number(task.totalDurationSec) || 0);
           const leaf = {
             tier: 'task', label: clipLabel(task.title, 14),
-            tip: clipLabel(task.title, 40) + (task.day ? ' · ' + task.day : ''),
-            color: taskColor, rgb: rgbString(taskColor), r: 5.5, x: 0, y: 0,
+            tip: canvasGraph
+              ? clipLabel(task.title, 40) + ' · ' + durationLabel(taskSec, english)
+                + (totalTaskSec > taskSec
+                  ? (english ? ' · total ' : ' · 累计 ') + durationLabel(totalTaskSec, english) : '')
+                + (task.inferred && !taskSec ? (english ? ' · historical time unavailable' : ' · 历史时长无法还原') : '')
+              : clipLabel(task.title, 40) + (task.day ? ' · ' + task.day : ''),
+            color: taskColor, rgb: rgbString(taskColor),
+            r: canvasGraph ? clamp(5.5 + Math.log1p(taskSec / 60) * 1.15, 5.5, 13) : 5.5,
+            x: 0, y: 0,
           };
           const leafIndex = nodes.push(leaf) - 1;
           edges.push({ source: monthIndex, target: leafIndex, rest: 74 });
@@ -255,11 +302,17 @@
         years.forEach((year) => {
           const yearNode = {
             tier: 'year', label: String(year.year || ''),
-            tip: english
+            tip: canvasGraph
+              ? String(year.year || '') + (english ? ' · ' : ' 年 · ')
+                + (year.total || 0) + (english ? ' canvases · ' : ' 张画布 · ')
+                + durationLabel(year.durationSec || 0, english)
+              : english
               ? String(year.year || '') + ' · ' + (year.total || 0) + ' completed'
               : String(year.year || '') + ' 年 · 完成 ' + (year.total || 0) + ' 项',
             color: yearColor, rgb: rgbString(yearColor),
-            r: clamp(10 + (year.total || 0) * 0.34, 11, 19), x: 0, y: 0,
+            r: canvasGraph
+              ? clamp(11 + Math.log1p((year.durationSec || 0) / 3600) * 2.2, 11, 19)
+              : clamp(10 + (year.total || 0) * 0.34, 11, 19), x: 0, y: 0,
           };
           const yearIndex = nodes.push(yearNode) - 1;
           edges.push({ source: rootIndex, target: yearIndex, rest: 178 });

--- a/assets/study.js
+++ b/assets/study.js
@@ -979,8 +979,11 @@
   let starInstance = null;   // 足迹星图当前实例（活跃图重绘时先销毁旧实例再挂新的）
   let cadenceShown = false;  // 活跃页当前是否被选为前置页（起步页翻页时由 StudyActivity.setActive 同步）
   let starMode = 'normal';
-  let cadenceLens = 'complete';   // 活跃热力图镜头：'complete'(完成数) | 'focus'(专注时长)
-  try { if (localStorage.getItem('canvas:cadenceLens') === 'focus') cadenceLens = 'focus'; } catch (e) {}
+  let cadenceLens = 'canvas';   // v2 首次默认画布；之后记住 canvas / complete / focus
+  try {
+    const storedLens = localStorage.getItem('canvas:cadenceLens:v2');
+    if (storedLens === 'canvas' || storedLens === 'complete' || storedLens === 'focus') cadenceLens = storedLens;
+  } catch (e) {}
   let cadenceInteractionCleanup = null;
   const CADENCE = { cell: 16, gap: 4, leftPad: 38, topPad: 28 };
   const CADENCE_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
@@ -1024,6 +1027,52 @@
   function focusStatCell(sec, label) {
     const f = fmtFocusStat(sec);
     return '<div><strong>' + f.num + '<small> ' + f.unit + '</small></strong><span>' + label + '</span></div>';
+  }
+
+  function canvasStatCell(sec, label) {
+    if (Number(sec) > 0 && Number(sec) < 60) {
+      return '<div><strong>&lt;1<small> 分钟</small></strong><span>' + label + '</span></div>';
+    }
+    return focusStatCell(sec, label);
+  }
+
+  function fmtCanvasDuration(sec) {
+    sec = Math.max(0, Number(sec) || 0);
+    if (sec > 0 && sec < 60) return '不足 1 分钟';
+    return fmtFocusDur(Math.round(sec / 60));
+  }
+
+  function cadenceCanvasDayDetailHtml(day, entries, summary, todayKey) {
+    const items = (entries || []).filter((item) => item.day === day);
+    const future = day > todayKey;
+    const durationSec = Math.max(0, Number(summary && summary.durationSec) || 0);
+    let note = '这一天还没有画布使用记录。';
+    if (future) note = '这一天还在前方。';
+    else if (day === todayKey && !items.length) note = '今天还没有打开画布。';
+    const list = items.length
+      ? '<div class="cadence-day-detail-list">' + items.map((item, index) => {
+        const flags = [];
+        if (item.created) flags.push('<i>新建</i>');
+        if (item.modified) flags.push('<i>修改</i>');
+        if (item.inferred && !item.durationSec) flags.push('<i>历史记录</i>');
+        const duration = item.durationSec
+          ? '<span>' + escapeHtml(fmtCanvasDuration(item.durationSec)) + '</span>'
+          : '<span>历史时长无法还原</span>';
+        const open = item.canvasAvailable
+          ? '<button type="button" class="cadence-open-canvas cadence-day-open" data-canvas-path="'
+            + escapeHtml(item.path) + '">打开画布</button>'
+          : '';
+        return '<div class="cadence-day-detail-item cadence-canvas-detail-item" style="--detail-delay:'
+          + (index * 45) + 'ms"><span aria-hidden="true"></span><div class="cadence-record-copy">'
+          + '<strong>' + escapeHtml(item.title || '未命名画布') + '</strong>'
+          + '<span class="cadence-canvas-meta">' + flags.join('') + duration + '</span></div>' + open + '</div>';
+      }).join('') + '</div>'
+      : '<p class="cadence-day-detail-empty">' + note + '</p>';
+    const heading = items.length
+      ? '使用 ' + items.length + ' 张画布' + (durationSec ? ' · ' + fmtCanvasDuration(durationSec) : '')
+      : '安静的一天';
+    return '<div class="cadence-day-detail-copy"><p>' + escapeHtml(cadenceDateLabel(day, true)) + '</p>'
+      + '<h3>' + heading + '</h3></div>' + list;
   }
   function cadenceFocusDayDetailHtml(day, sec, count, todayKey) {
     const future = day > todayKey;
@@ -1173,7 +1222,10 @@
     if (starInstance) { try { starInstance.destroy(); } catch (e) {} starInstance = null; }
     const starStage = host.querySelector('[data-role="study-starmap"]');
     if (starStage && window.StudyGraph) {
-      const graph = starMode === 'overview' ? (payload.overviewGraph || {}) : (payload.graph || {});
+      const canvasLens = cadenceLens === 'canvas';
+      const graph = starMode === 'overview'
+        ? (canvasLens ? (payload.canvasOverviewGraph || {}) : (payload.overviewGraph || {}))
+        : (canvasLens ? (payload.canvasGraph || {}) : (payload.graph || {}));
       // 活跃页不是当前前置页时，星图以挂起态挂载（建好静态帧但不空转 RAF），进入活跃页再唤醒。
       starInstance = window.StudyGraph.mount(starStage, graph, {
         active: cadenceShown,
@@ -1212,6 +1264,9 @@
     const recent = payload.recent || [];
     const focusDays = payload.focusDays || {};   // { 'YYYY-MM-DD': {sec,count} } 当年逐日专注
     const focusStats = payload.focusStats || {};  // { today, month, year, total }（秒）
+    const canvasDays = payload.canvasDays || {};
+    const canvasEntries = payload.canvasEntries || [];
+    const canvasStats = payload.canvasStats || {};
     const C = CADENCE;
     const step = C.cell + C.gap;
     const now = new Date();
@@ -1266,18 +1321,30 @@
         const ftip = cadenceDateLabel(key, false) + (future
           ? ' · 尚未到来'
           : fmin ? ' · 专注 ' + fmtFocusDur(fmin) : ' · 未专注');
+        const cd = canvasDays[key] || {};
+        const csec = Math.max(0, Number(cd.durationSec) || 0);
+        const cmin = csec ? Math.max(1, Math.ceil(csec / 60)) : 0;
+        const clv = cadenceFocusLevel(cmin);
+        const canvasHistorical = !!cd.inferred && !csec;
+        const ctip = cadenceDateLabel(key, false) + (future
+          ? ' · 尚未到来'
+          : csec ? ' · 画布 ' + fmtCanvasDuration(csec)
+            : canvasHistorical ? ' · 有历史画布记录，时长无法还原' : ' · 未使用画布');
+        const activeTip = cadenceLens === 'canvas' ? ctip : (cadenceLens === 'focus' ? ftip : tip);
         rects.push('<rect x="' + (C.leftPad + w * step) + '" y="' + (C.topPad + d * step)
           + '" width="' + C.cell + '" height="' + C.cell + '" rx="3" class="cadence-cell cadence-l'
-          + lv + ' cadence-fl' + flv + (count ? ' has-activity' : '') + (future ? ' is-future' : '')
+          + lv + ' cadence-fl' + flv + ' cadence-cl' + clv + (count ? ' has-activity' : '')
+          + (canvasHistorical ? ' has-canvas-history' : '') + (future ? ' is-future' : '')
           + (isToday ? ' is-today' : '')
           + '" style="--cadence-delay:' + Math.round(Math.min(760, d * 92 + w * 5))
           + 'ms" data-wave-x="' + (C.leftPad + w * step + C.cell / 2) + '" data-wave-y="'
           + (C.topPad + d * step + C.cell / 2) + '" data-wave-w="' + w + '" data-wave-d="' + d
           + '" data-month="' + cell.getMonth() + '" data-day-key="' + key + '" data-count="' + count
           + '" data-focus-min="' + fmin + '" data-focus-count="' + fcount
-          + '" data-tip="' + escapeHtml(tip) + '" data-tip-focus="' + escapeHtml(ftip)
+          + '" data-canvas-sec="' + csec + '" data-tip="' + escapeHtml(tip)
+          + '" data-tip-focus="' + escapeHtml(ftip) + '" data-tip-canvas="' + escapeHtml(ctip)
           + '" tabindex="' + (future ? '-1' : '0')
-          + '" role="button" aria-label="' + escapeHtml(cadenceLens === 'focus' ? ftip : tip) + '"></rect>');
+          + '" role="button" aria-label="' + escapeHtml(activeTip) + '"></rect>');
       }
     }
     const dayLabels = [[0, 'Mon'], [2, 'Wed'], [4, 'Fri']].map((p) =>
@@ -1289,7 +1356,8 @@
     const statOneLabel = currentYear ? '本月完成' : year + ' 年完成';
     const statTwo = currentYear ? (stats.streak || 0) : (stats.longestStreak || 0);
     const statTwoLabel = currentYear ? '连续推进' : '最长连续';
-    const activeKeys = Object.keys(days).filter((key) => days[key] && key <= todayKey).sort();
+    const activeSource = cadenceLens === 'canvas' ? canvasDays : (cadenceLens === 'focus' ? focusDays : days);
+    const activeKeys = Object.keys(activeSource).filter((key) => activeSource[key] && key <= todayKey).sort();
     const initialDay = currentYear
       ? todayKey
       : (activeKeys[activeKeys.length - 1] || year + '-01-01');
@@ -1300,6 +1368,7 @@
         + '<div class="cadence-head-tools">'
         + '<div class="cadence-lens-switch" data-role="cadence-lens-switch" data-active="' + cadenceLens + '" aria-label="热力图查看">'
           + '<span class="cadence-lens-slider" aria-hidden="true"></span>'
+          + '<button type="button" class="cadence-lens-btn' + (cadenceLens === 'canvas' ? ' active' : '') + '" data-lens="canvas">画布</button>'
           + '<button type="button" class="cadence-lens-btn' + (cadenceLens === 'complete' ? ' active' : '') + '" data-lens="complete">完成</button>'
           + '<button type="button" class="cadence-lens-btn' + (cadenceLens === 'focus' ? ' active' : '') + '" data-lens="focus">专注</button>'
         + '</div>'
@@ -1315,7 +1384,7 @@
         + '<span class="cadence-legend-cell cadence-l7"></span>'
         + '</span><span>丰</span></div>'
         + '<button type="button" class="page-refresh" data-cadence-refresh'
-        + ' aria-label="重新读取活跃数据" title="重新统计一年活跃热力图（平时翻进来用上次结果；完成任务/专注后想立刻看到，点这里）">'
+        + ' aria-label="重新读取活跃数据" title="重新统计一年活跃热力图（画布计时、完成任务或专注后想立刻看到，点这里）">'
         + '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 3v6h-6"/></svg>'
         + '<span>更新</span></button>'
         + '</div>'
@@ -1324,20 +1393,31 @@
         + '<div class="cadence-chart-wrap">'
         + '<svg class="cadence-chart" viewBox="0 0 ' + svgW + ' ' + svgH + '" width="' + svgW
         + '" height="' + svgH + '" xmlns="http://www.w3.org/2000/svg" role="img"'
-        + ' aria-label="' + year + ' 年逐日已完成任务热力图">'
+        + ' aria-label="' + year + (cadenceLens === 'canvas' ? ' 年逐日画布使用时长热力图'
+          : cadenceLens === 'focus' ? ' 年逐日专注时长热力图' : ' 年逐日已完成任务热力图') + '">'
         + monthLabels.join('') + dayLabels.join('') + rects.join('')
         + '</svg>'
         + '</div>'
         + '<div class="cadence-chart-caption"><span><i class="is-today-mark"></i>今天</span>'
           + '<span><i class="is-future-mark"></i>尚未到来</span>'
-          + '<p>悬停回望，点击展开当天成果</p></div>'
+          + '<p>' + (cadenceLens === 'canvas' ? '悬停回望，点击展开当天画布' : '悬停回望，点击展开当天成果') + '</p></div>'
       + '</div>'
       + '<section class="cadence-day-detail" data-role="cadence-day-detail" aria-live="polite">'
-        + (cadenceLens === 'focus'
+        + (cadenceLens === 'canvas'
+          ? cadenceCanvasDayDetailHtml(initialDay, canvasEntries, canvasDays[initialDay] || {}, todayKey)
+          : cadenceLens === 'focus'
             ? cadenceFocusDayDetailHtml(initialDay, (focusDays[initialDay] || {}).sec || 0,
                 (focusDays[initialDay] || {}).count || 0, todayKey)
             : cadenceDayDetailHtml(initialDay, entries, days[initialDay] || 0, todayKey))
       + '</section>'
+      + '<div class="cadence-stats cadence-stats-canvas" aria-label="画布时间统计">'
+        + canvasStatCell(currentYear ? canvasStats.monthSec : canvasStats.yearSec,
+          currentYear ? '本月画布时间' : '当年画布时间')
+        + '<div><strong>' + (currentYear ? (canvasStats.streak || 0) : (canvasStats.longestStreak || 0))
+          + '<small> 天</small></strong><span>' + (currentYear ? '连续活跃' : '最长连续') + '</span></div>'
+        + '<div><strong>' + (canvasStats.activeCanvasCount || 0) + '</strong><span>活跃画布</span></div>'
+        + canvasStatCell(canvasStats.totalSec, '累计画布时间')
+      + '</div>'
       + '<div class="cadence-stats cadence-stats-complete" aria-label="活跃统计">'
         + '<div><strong>' + statOne + '</strong><span>' + statOneLabel + '</span></div>'
         + '<div><strong>' + statTwo + '<small> 天</small></strong><span>' + statTwoLabel + '</span></div>'
@@ -1352,7 +1432,7 @@
       + '</div>'
       + '<section class="cadence-starmap">'
         + '<div class="cadence-starmap-head"><div><p class="study-eyebrow">STARMAP</p>'
-          + '<h3>足迹星图</h3></div>'
+          + '<h3 data-role="cadence-starmap-title">' + (cadenceLens === 'canvas' ? '画布星图' : '足迹星图') + '</h3></div>'
           + '<div class="cadence-starmap-tools">'
             + '<div class="star-mode-switch" data-role="star-mode-switch" aria-label="星图查看模式">'
               + '<span class="star-mode-slider" data-role="star-mode-slider" aria-hidden="true"></span>'
@@ -1379,6 +1459,7 @@
         + '" data-role="cadence-year-page">' + contentHtml + '</div>'
       + '<div class="cadence-tooltip" role="status" aria-hidden="true"></div>';
     host.classList.toggle('cadence-lens-focus', cadenceLens === 'focus');
+    host.classList.toggle('cadence-lens-canvas', cadenceLens === 'canvas');
     const yearPage = host.querySelector('[data-role="cadence-year-page"]');
     if (incoming && yearPage && !prefersReduced) {
       void yearPage.offsetHeight;
@@ -1421,8 +1502,11 @@
     }
     let selectedDay = initialDay;
     let detailHeightAnim = null;   // 切换日期时的高度补间句柄；快速连切时先取消旧的，避免叠加
-    // 当天详情按当前镜头取内容：完成镜头=当天完成的任务列表；专注镜头=当天专注时长 / 段数。
+    // 当天详情按当前镜头取内容：画布时间 / 完成记录 / 专注时长。
     function detailHtmlForDay(day) {
+      if (cadenceLens === 'canvas') {
+        return cadenceCanvasDayDetailHtml(day, canvasEntries, canvasDays[day] || {}, todayKey);
+      }
       if (cadenceLens === 'focus') {
         const fd = focusDays[day] || {};
         return cadenceFocusDayDetailHtml(day, fd.sec || 0, fd.count || 0, todayKey);
@@ -1473,16 +1557,31 @@
         button.addEventListener('click', () => {
           const next = button.dataset.lens;
           if (next === cadenceLens) return;
+          const remountStar = (next === 'canvas') !== (cadenceLens === 'canvas');
           cadenceLens = next;
-          try { localStorage.setItem('canvas:cadenceLens', cadenceLens); } catch (e) {}
+          try { localStorage.setItem('canvas:cadenceLens:v2', cadenceLens); } catch (e) {}
           lensSwitch.dataset.active = cadenceLens;
           lensSwitch.querySelectorAll('.cadence-lens-btn').forEach((b) =>
             b.classList.toggle('active', b.dataset.lens === cadenceLens));
           host.classList.toggle('cadence-lens-focus', cadenceLens === 'focus');
+          host.classList.toggle('cadence-lens-canvas', cadenceLens === 'canvas');
           cells.forEach((cell) => {
-            cell.setAttribute('aria-label',
-              cadenceLens === 'focus' ? (cell.dataset.tipFocus || cell.dataset.tip) : cell.dataset.tip);
+            const label = cadenceLens === 'canvas'
+              ? (cell.dataset.tipCanvas || cell.dataset.tip)
+              : cadenceLens === 'focus' ? (cell.dataset.tipFocus || cell.dataset.tip) : cell.dataset.tip;
+            cell.setAttribute('aria-label', label);
           });
+          const starTitle = host.querySelector('[data-role="cadence-starmap-title"]');
+          if (starTitle) starTitle.textContent = cadenceLens === 'canvas' ? '画布星图' : '足迹星图';
+          const chart = host.querySelector('.cadence-chart');
+          if (chart) chart.setAttribute('aria-label', year + (cadenceLens === 'canvas'
+            ? ' 年逐日画布使用时长热力图'
+            : cadenceLens === 'focus' ? ' 年逐日专注时长热力图' : ' 年逐日已完成任务热力图'));
+          const chartCaption = host.querySelector('.cadence-chart-caption p');
+          if (chartCaption) chartCaption.textContent = cadenceLens === 'canvas'
+            ? '悬停回望，点击展开当天画布'
+            : '悬停回望，点击展开当天成果';
+          if (remountStar) mountStarGraph(host, payload, { intro: true });
           applyDayDetail();
         });
       });
@@ -1590,8 +1689,9 @@
         const hostRect = geometry ? geometry.host : host.getBoundingClientRect();
         if (cell !== tooltipCell) {
           tooltipCell = cell;
-          tooltip.textContent = (cadenceLens === 'focus' && cell.dataset.tipFocus)
-            ? cell.dataset.tipFocus : cell.dataset.tip;
+          tooltip.textContent = cadenceLens === 'canvas' && cell.dataset.tipCanvas
+            ? cell.dataset.tipCanvas
+            : (cadenceLens === 'focus' && cell.dataset.tipFocus) ? cell.dataset.tipFocus : cell.dataset.tip;
           tooltip.classList.add('is-visible');
           tooltip.setAttribute('aria-hidden', 'false');
         }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -444,8 +444,8 @@ body.desktop-host.desktop-maximized {
 .cadence-lens-switch {
   position: relative;
   display: grid;
-  grid-template-columns: repeat(2, minmax(48px, 1fr));
-  min-width: 112px;
+  grid-template-columns: repeat(3, minmax(48px, 1fr));
+  min-width: 166px;
   padding: 3px;
   border: 1px solid var(--border);
   border-radius: 999px;
@@ -456,15 +456,18 @@ body.desktop-host.desktop-maximized {
   top: 3px;
   bottom: 3px;
   left: 3px;
-  width: calc(50% - 3px);
+  width: calc(33.333% - 2px);
   border-radius: 999px;
   background: var(--surface);
   box-shadow: 0 1px 4px rgba(26, 26, 26, 0.09);
   transform: translateX(0);
   transition: transform 260ms var(--easing-page), background 220ms var(--easing-soft);
 }
-.cadence-lens-switch[data-active="focus"] .cadence-lens-slider {
+.cadence-lens-switch[data-active="complete"] .cadence-lens-slider {
   transform: translateX(100%);
+}
+.cadence-lens-switch[data-active="focus"] .cadence-lens-slider {
+  transform: translateX(200%);
 }
 .cadence-lens-btn {
   position: relative;
@@ -709,6 +712,28 @@ body.desktop-host.desktop-maximized {
 .cadence-lens-focus .cadence-month.is-focused,
 .cadence-lens-focus .cadence-day.is-focused {
   fill: var(--focus-cadence-ink);
+}
+
+.cadence-lens-canvas .cadence-cell:not(.is-future).cadence-cl0,
+.cadence-lens-canvas .cadence-legend-cell.cadence-l0 { --c: var(--cadence-empty); fill: var(--c); background: var(--c); }
+.cadence-lens-canvas .cadence-cell:not(.is-future).cadence-cl1,
+.cadence-lens-canvas .cadence-legend-cell.cadence-l1 { --c: var(--cadence-1); fill: var(--c); background: var(--c); }
+.cadence-lens-canvas .cadence-cell:not(.is-future).cadence-cl2,
+.cadence-lens-canvas .cadence-legend-cell.cadence-l2 { --c: var(--cadence-2); fill: var(--c); background: var(--c); }
+.cadence-lens-canvas .cadence-cell:not(.is-future).cadence-cl3,
+.cadence-lens-canvas .cadence-legend-cell.cadence-l3 { --c: var(--cadence-3); fill: var(--c); background: var(--c); }
+.cadence-lens-canvas .cadence-cell:not(.is-future).cadence-cl4,
+.cadence-lens-canvas .cadence-legend-cell.cadence-l4 { --c: var(--cadence-4); fill: var(--c); background: var(--c); }
+.cadence-lens-canvas .cadence-cell:not(.is-future).cadence-cl5,
+.cadence-lens-canvas .cadence-legend-cell.cadence-l5 { --c: var(--cadence-5); fill: var(--c); background: var(--c); }
+.cadence-lens-canvas .cadence-cell:not(.is-future).cadence-cl6,
+.cadence-lens-canvas .cadence-legend-cell.cadence-l6 { --c: var(--cadence-6); fill: var(--c); background: var(--c); }
+.cadence-lens-canvas .cadence-cell:not(.is-future).cadence-cl7,
+.cadence-lens-canvas .cadence-legend-cell.cadence-l7 { --c: var(--cadence-7); fill: var(--c); background: var(--c); }
+.cadence-lens-canvas .cadence-cell.has-canvas-history:not(.is-future) {
+  stroke: color-mix(in srgb, var(--cadence-4) 78%, var(--text));
+  stroke-width: 1.35px;
+  stroke-dasharray: 2 1.5;
 }
 
 .cadence-month {
@@ -959,6 +984,7 @@ body.desktop-host.desktop-maximized {
 }
 .cadence-stats div:hover strong { letter-spacing: -0.065em; }
 .cadence-stats small {
+  margin-left: 0.18em;
   color: var(--text-secondary);
   font-family: var(--font-ui);
   font-size: 14px;
@@ -974,10 +1000,31 @@ body.desktop-host.desktop-maximized {
   font-weight: 600;
   letter-spacing: 0.025em;
 }
-.cadence-stats-focus { display: none; }
+.cadence-stats-focus,
+.cadence-stats-canvas { display: none; }
 .cadence-lens-focus .cadence-stats-complete { display: none; }
 .cadence-lens-focus .cadence-stats-focus { display: grid; }
+.cadence-lens-canvas .cadence-stats-complete { display: none; }
+.cadence-lens-canvas .cadence-stats-canvas { display: grid; }
 .cadence-stats-focus strong small { font-size: 12px; }
+.cadence-stats-canvas strong small { font-size: 12px; }
+
+.cadence-canvas-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 5px;
+  color: var(--text-tertiary);
+  font: 560 11px/1.3 var(--font-ui);
+}
+.cadence-canvas-meta i {
+  padding: 2px 6px;
+  border: 1px solid color-mix(in srgb, var(--cadence-4) 34%, var(--border));
+  border-radius: 999px;
+  color: color-mix(in srgb, var(--cadence-7) 72%, var(--text));
+  font-style: normal;
+}
 
 /* —— 足迹星图（活跃页，热力图与「最近完成」之间）—— */
 .cadence-starmap {
@@ -7824,9 +7871,8 @@ body[data-hide-special="1"] .empty-actions [data-action="study-view"] {
   to { stroke-dashoffset: var(--focus-ring-target); }
 }
 @keyframes focus-ring-wake {
-  0% { opacity: 0.72; transform: scale(0.965); }
-  58% { opacity: 1; transform: scale(1.012); }
-  100% { opacity: 1; transform: scale(1); }
+  from { opacity: 0.72; }
+  to { opacity: 1; }
 }
 .focus-ring-wrap[data-phase="break"] .focus-ring-fill { stroke: #b08968; }   /* 休息=暖色，区别于专注的深色 */
 .focus-ring-wrap[data-phase="break"] { animation: focus-breathe 4.4s ease-in-out infinite; }
@@ -8430,8 +8476,8 @@ body.start-page[data-start-theme="dark"] .focus-overlay-card {
 .focus-reentering .focus-controls { animation-delay: 290ms; }
 .focus-reentering .focus-footprint { animation-delay: 340ms; }
 @keyframes focus-section-enter {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 @media (prefers-reduced-motion: reduce) {
   .focus-help-btn.is-inviting,
@@ -8730,93 +8776,18 @@ body.start-page[data-start-theme="dark"] .focus-overlay-card {
 .focus-footprint-note { font-size: 11px; }
 [data-role="focus-view"][data-has-sessions="0"] .focus-footprint { min-height: 24px; }
 
-/* ── 专注页「每日任务」侧栏（习惯清单，Tab 开合；与学习任务、.canvas 解耦）──────── */
-.focus-daily-handle {
-  position: absolute;
-  top: 50%;
-  right: 0;
-  z-index: 14;
-  transform: translateY(-50%);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 9px;
-  padding: 15px 9px;
-  border: 1px solid var(--border);
-  border-right: 0;
-  border-radius: 14px 0 0 14px;
-  background: color-mix(in srgb, var(--surface) 80%, transparent);
-  box-shadow: 0 14px 36px rgba(39, 37, 31, 0.1);
-  backdrop-filter: blur(14px) saturate(1.05);
-  -webkit-backdrop-filter: blur(14px) saturate(1.05);
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: transform 320ms var(--easing-soft), opacity 260ms var(--easing-soft),
-              color 240ms var(--easing-soft), box-shadow 260ms var(--easing-soft);
-}
-.focus-daily-handle:hover {
-  color: var(--text);
-  transform: translateY(-50%) translateX(-3px);
-  box-shadow: 0 18px 42px rgba(39, 37, 31, 0.14);
-}
-.focus-daily-handle-text { writing-mode: vertical-rl; letter-spacing: 3px; font-size: 13px; font-weight: 600; }
-.focus-daily-handle kbd {
-  padding: 2px 5px;
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  background: color-mix(in srgb, var(--surface) 70%, transparent);
-  color: var(--text-tertiary);
-  font: inherit;
-  font-size: 10px;
-}
-.book-view.focus-daily-open .focus-daily-handle {
-  opacity: 0;
-  pointer-events: none;
-  transform: translateY(-50%) translateX(22px);
-}
-
+/* ── 专注页「每日任务」清单基础组件；V2 的完整页布局见后文。 ──────── */
 .focus-daily {
-  position: absolute;
-  top: clamp(42px, 6vh, 58px);
-  right: clamp(14px, 3vw, 52px);
-  bottom: clamp(8px, 1.5vh, 16px);
-  z-index: 15;
-  width: clamp(360px, 32vw, 440px);
   display: flex;
   flex-direction: column;
   gap: 14px;
-  padding: 22px 22px 20px;
-  border: 1px solid var(--border);
-  border-radius: 22px;
-  background:
-    radial-gradient(120% 80% at 80% 0%, color-mix(in srgb, var(--accent) 4%, transparent), transparent 70%),
-    color-mix(in srgb, var(--surface) 84%, transparent);
-  box-shadow: 0 30px 80px rgba(39, 37, 31, 0.16);
-  backdrop-filter: blur(22px) saturate(1.1);
-  -webkit-backdrop-filter: blur(22px) saturate(1.1);
-  opacity: 0;
-  pointer-events: none;
-  transform: translateX(calc(100% + 64px));
-  transition: transform 560ms var(--easing-page), opacity 400ms var(--easing-soft);
-  overflow: hidden;
 }
-.focus-daily.is-open { opacity: 1; pointer-events: auto; transform: translateX(0); }
-.focus-daily.is-closing {
-  pointer-events: none;
-  animation: focus-daily-panel-out 340ms var(--easing-soft) both;
-}
-.focus-daily.is-celebrate-ready { animation: focus-daily-panel-settle 760ms var(--easing-page) both; }
 /* display:flex 会盖过 [hidden] 的 display:none，显式补回，保证初始/切换真正隐藏 */
 .focus-daily[hidden],
-.focus-daily-list[hidden],
-.focus-daily-celebrate[hidden] { display: none; }
+.focus-daily-list[hidden] { display: none; }
 .focus-daily-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; flex: none; }
 .focus-daily-head h2 { margin: 2px 0 0; font-size: 20px; font-weight: 660; color: var(--text); }
 .focus-daily-head .study-eyebrow { margin: 0; }
-.focus-daily.is-revealing .focus-daily-head {
-  animation: focus-daily-panel-piece 560ms 70ms var(--easing-page) both;
-}
-
 .focus-daily-list {
   flex: 1 1 auto;
   display: flex;
@@ -8828,6 +8799,7 @@ body.start-page[data-start-theme="dark"] .focus-overlay-card {
 }
 .focus-daily-empty { margin: 20px 6px; color: var(--text-tertiary); font-size: 12.5px; line-height: 1.7; text-align: center; }
 .focus-daily-row {
+  position: relative;
   display: flex;
   align-items: flex-start;
   gap: 11px;
@@ -8835,7 +8807,6 @@ body.start-page[data-start-theme="dark"] .focus-overlay-card {
   border-radius: 13px;
   transition: background 200ms var(--easing-soft), opacity 200ms var(--easing-soft),
               box-shadow 220ms var(--easing-soft), filter 220ms var(--easing-soft);
-  will-change: transform;
 }
 .focus-daily-row:hover { background: color-mix(in srgb, var(--text) 4%, transparent); }
 /* 任务行 ⋯ 选项按钮：默认透明，悬停该行或正在编辑时浮现；只有它能进编辑（命中区收小，对齐分组 ⋯） */
@@ -8889,31 +8860,6 @@ body.start-page[data-start-theme="dark"] .focus-overlay-card {
   color: #5f9e6c;
   background: color-mix(in srgb, #5f9e6c 14%, transparent);
 }
-/* 点任务名/空白处的反馈：⋯ 明显弹跳并「点亮」成强调色（清楚提示编辑入口）+ 整行轻按下+强调色闪，不改任何状态 */
-.focus-daily-row.is-hint .focus-daily-menu {
-  opacity: 1;
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 18%, transparent);
-  animation: focus-daily-menu-hint 600ms var(--easing-soft);
-}
-.focus-daily-row.is-hint { animation: focus-daily-row-tap 600ms var(--easing-soft); }
-@keyframes focus-daily-menu-hint {
-  0% { transform: scale(1); }
-  26% { transform: scale(1.45) rotate(-4deg); }
-  52% { transform: scale(0.88) rotate(2deg); }
-  76% { transform: scale(1.12); }
-  100% { transform: scale(1) rotate(0); }
-}
-@keyframes focus-daily-row-tap {
-  0% { transform: scale(1); background: color-mix(in srgb, var(--accent) 0%, transparent); }
-  20% { transform: scale(0.982); background: color-mix(in srgb, var(--accent) 14%, transparent); }
-  50% { transform: scale(1.004); }
-  100% { transform: scale(1); background: color-mix(in srgb, var(--accent) 0%, transparent); }
-}
-@media (prefers-reduced-motion: reduce) {
-  .focus-daily-row.is-hint .focus-daily-menu,
-  .focus-daily-row.is-hint { animation: none; }
-}
 .focus-daily-row.is-dragging {
   opacity: 0.18;
   cursor: grabbing;
@@ -8941,14 +8887,6 @@ body.focus-daily-dragging * {
   user-select: none;
 }
 body.focus-daily-dragging .focus-daily-row { will-change: transform; }
-.focus-daily.is-revealing .focus-daily-row {
-  animation: focus-daily-panel-piece 560ms var(--easing-page) both;
-  animation-delay: calc(200ms + var(--daily-row-index, 0) * 66ms);
-}
-.focus-daily.is-peeking .focus-daily-row {
-  animation: focus-daily-row-return 430ms var(--easing-page) both;
-  animation-delay: calc(45ms + var(--daily-row-index, 0) * 42ms);
-}
 .focus-daily-check {
   flex: none;
   width: 21px;
@@ -9020,7 +8958,6 @@ body.focus-daily-dragging .focus-daily-row { will-change: transform; }
 }
 .focus-daily-row.is-done .focus-daily-name::after { transform: scaleX(1); }
 .focus-daily-stat { margin-top: 3px; color: var(--text-tertiary); font-size: 11.5px; line-height: 1.5; }
-.focus-daily-stat.is-updating { animation: focus-daily-stat-pop 260ms var(--easing-soft) both; }
 .focus-daily-row.is-done .focus-daily-stat { opacity: 0.72; }
 .focus-daily-goal-shell {
   position: relative;
@@ -9180,7 +9117,7 @@ body.focus-daily-dragging .focus-daily-row { will-change: transform; }
 
 /* —— 分组：就地折叠手风琴。任务/分组同列，靠 --daily-depth 缩进表达层级 —— */
 .focus-daily-row { padding-left: calc(8px + var(--daily-depth, 0) * 16px); }
-.focus-daily-group { display: flex; flex-direction: column; will-change: transform; }
+.focus-daily-group { display: flex; flex-direction: column; }
 /* 子树容器：靠 grid-template-rows 1fr↔0fr 平滑收合（不重建 → 不瞬移），下方自然回流 */
 .focus-daily-group-children {
   display: grid;
@@ -9229,7 +9166,7 @@ body.focus-daily-dragging .focus-daily-row { will-change: transform; }
 /* 分组就地展开：直接子项逐个揭示（沿用面板打开的逐行入场手法），比整块冒出更细腻 */
 .focus-daily-group.is-expanding > .focus-daily-group-children > .focus-daily-group-children-inner > .focus-daily-row,
 .focus-daily-group.is-expanding > .focus-daily-group-children > .focus-daily-group-children-inner > .focus-daily-group {
-  animation: focus-daily-row-in 400ms var(--easing-soft) both;
+  animation: focus-daily-card-spring-in 520ms var(--easing-page) both;
   animation-delay: calc(var(--daily-expand-index, 0) * 66ms);
 }
 /* 分组折叠：子项反向交错逐层收拢（最深的先走），比纯 grid-rows 一刀切更细腻 */
@@ -9351,14 +9288,6 @@ body.focus-daily-dragging .focus-daily-row { will-change: transform; }
 }
 .focus-daily-subact:hover { color: var(--text); background: color-mix(in srgb, var(--text) 7%, transparent); }
 .focus-daily-subact:active { transform: scale(0.97); }
-.focus-daily.is-revealing .focus-daily-group {
-  animation: focus-daily-panel-piece 560ms var(--easing-page) both;
-  animation-delay: calc(200ms + var(--daily-row-index, 0) * 66ms);
-}
-.focus-daily.is-peeking .focus-daily-group {
-  animation: focus-daily-row-return 430ms var(--easing-page) both;
-  animation-delay: calc(45ms + var(--daily-row-index, 0) * 42ms);
-}
 .focus-daily-group.is-entering { animation: focus-daily-row-in 440ms var(--easing-page) both; }
 
 /* 二期拖拽：落点指示线（缩进体现目标层级）+ 拖整组时子树淡出 */
@@ -9434,8 +9363,6 @@ body.focus-daily-dragging .focus-daily-group-head {
 
 /* 新增控制条：任务 / 分组模式 + 目标父分组药丸 */
 .focus-daily-compose { display: flex; align-items: center; gap: 8px; flex: none; flex-wrap: wrap; }
-.focus-daily.is-revealing .focus-daily-compose { animation: focus-daily-panel-piece 560ms 350ms var(--easing-page) both; }
-.focus-daily.is-completing .focus-daily-compose { opacity: 0.24; transform: translateY(5px); }
 .focus-daily-compose-modes {
   display: inline-flex;
   padding: 2px;
@@ -9699,12 +9626,6 @@ body.focus-daily-dragging .focus-daily-group-head {
   flex: none;
   transition: opacity 260ms var(--easing-soft), transform 320ms var(--easing-soft);
 }
-.focus-daily.is-revealing .focus-daily-add {
-  animation: focus-daily-panel-piece 560ms 310ms var(--easing-page) both;
-}
-.focus-daily.is-peeking .focus-daily-add {
-  animation: focus-daily-panel-piece 420ms 210ms var(--easing-page) both;
-}
 .focus-daily-add.is-dimmed { opacity: 0.4; pointer-events: none; }
 .focus-daily-add input {
   flex: 1 1 auto;
@@ -9741,12 +9662,6 @@ body.focus-daily-dragging .focus-daily-group-head {
   font-size: 11.5px;
   text-align: center;
   transition: opacity 260ms var(--easing-soft), transform 320ms var(--easing-soft);
-}
-.focus-daily.is-revealing .focus-daily-foot {
-  animation: focus-daily-panel-piece 560ms 390ms var(--easing-page) both;
-}
-.focus-daily.is-peeking .focus-daily-foot {
-  animation: focus-daily-panel-piece 420ms 280ms var(--easing-page) both;
 }
 .focus-daily-foot.is-updating { animation: focus-daily-foot-pop 280ms var(--easing-soft) both; }
 .focus-daily-history {
@@ -10364,168 +10279,250 @@ body.focus-daily-dragging .focus-daily-group-head {
     min-height: 520px;
   }
 }
-.focus-daily.is-completing .focus-daily-add,
-.focus-daily.is-completing .focus-daily-foot {
-  opacity: 0.24;
-  transform: translateY(5px);
-  transition: opacity 300ms var(--easing-soft), transform 300ms var(--easing-soft);
-}
 
 .focus-daily-celebrate {
+  --daily-star-gold: #c99535;
   position: absolute;
-  inset: 72px 22px 22px;
-  z-index: 2;
+  inset: 0;
+  z-index: 4;
+  display: grid;
+  place-items: center;
+  width: auto;
+  height: auto;
+  min-height: 0;
+  margin: 0;
+  padding: clamp(42px, 8vh, 88px) clamp(24px, 5vw, 76px);
+  box-sizing: border-box;
+  color: var(--text);
+  text-align: center;
+  background:
+    radial-gradient(circle at 50% 45%, color-mix(in srgb, var(--daily-star-gold) 7%, transparent), transparent 34%),
+    color-mix(in srgb, var(--bg) 96%, var(--surface) 4%);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 330ms var(--easing-soft),
+    visibility 0s linear 330ms;
+}
+.focus-daily-celebrate.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition-delay: 100ms, 0s;
+}
+.focus-daily-celebrate.is-entering {
+  transition-duration: 520ms, 0s;
+  transition-delay: 620ms, 0s;
+}
+.focus-daily-celebrate.is-static,
+.focus-daily-celebrate.is-static .focus-daily-celebrate-inner { transition: none !important; }
+.focus-daily-celebrate.is-leaving {
+  opacity: 0;
+  visibility: visible;
+  pointer-events: none;
+  transition-duration: 260ms, 0s;
+  transition-delay: 0s, 260ms;
+}
+.focus-daily-celebrate-inner {
+  width: min(520px, 100%);
+  min-height: 260px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 11px;
-  text-align: center;
-  background: color-mix(in srgb, var(--surface) 36%, transparent);
-  overflow: hidden;
-}
-.focus-daily-celebrate > * {
-  position: relative;
-  z-index: 1;
-}
-.focus-daily-celebrate::before {
-  content: '';
-  position: absolute;
-  inset: 18px -30px;
-  z-index: 0;
-  background: linear-gradient(115deg,
-    transparent 18%,
-    color-mix(in srgb, #e0b34d 10%, transparent) 42%,
-    transparent 68%);
+  gap: 12px;
+  padding: 24px;
+  box-sizing: border-box;
   opacity: 0;
-  transform: translateX(-28%) skewX(-10deg);
+  transform: translateY(10px) scale(0.992);
+  transition: opacity 360ms 100ms var(--easing-soft), transform 620ms 100ms var(--easing-page);
+}
+.focus-daily-celebrate.is-visible .focus-daily-celebrate-inner {
+  opacity: 1;
+  transform: translateY(0);
+}
+.focus-daily-celebrate.is-entering .focus-daily-celebrate-inner {
+  transition-delay: 850ms, 850ms;
+}
+.focus-daily-celebrate.is-leaving .focus-daily-celebrate-inner {
+  opacity: 0;
+  transform: translateY(6px) scale(0.996);
+  transition-duration: 190ms, 260ms;
+  transition-delay: 0s, 0s;
+}
+.focus-daily-star-gather {
+  position: relative;
+  width: 174px;
+  height: 64px;
+  flex: 0 0 64px;
+}
+.focus-daily-star-main,
+.focus-daily-star-halo,
+.focus-daily-star-dot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
   pointer-events: none;
 }
-.focus-daily.is-revealing .focus-daily-celebrate:not([hidden]) {
-  animation: focus-daily-celebrate-return 560ms 150ms var(--easing-page) both;
+.focus-daily-star-main {
+  width: 29px;
+  height: 29px;
+  margin: -14.5px 0 0 -14.5px;
+  background: var(--daily-star-gold);
+  clip-path: polygon(50% 0, 58% 41%, 100% 50%, 58% 59%, 50% 100%, 42% 59%, 0 50%, 42% 41%);
 }
-.focus-daily-celebrate strong { font-size: 17px; font-weight: 660; color: var(--text); }
-.focus-daily-celebrate-sub { font-size: 12.5px; color: var(--text-secondary); }
-.focus-daily-celebrate-burst {
-  width: 56px;
-  height: 56px;
+.focus-daily-star-halo {
+  width: 44px;
+  height: 44px;
+  margin: -22px 0 0 -22px;
+  border: 1px solid color-mix(in srgb, var(--daily-star-gold) 38%, transparent);
   border-radius: 50%;
-  background: radial-gradient(circle, #ecce82 0%, #e0b34d 58%, color-mix(in srgb, #e0b34d 0%, transparent) 72%);
-  position: relative;
+  opacity: 0;
 }
-.focus-daily-celebrate-burst::before {
-  content: '✦';
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #6b4e12;
-  font-size: 24px;
+.focus-daily-star-dot {
+  width: var(--dot-size, 4px);
+  height: var(--dot-size, 4px);
+  margin: calc(var(--dot-size, 4px) / -2) 0 0 calc(var(--dot-size, 4px) / -2);
+  border-radius: 50%;
+  background: var(--daily-star-gold);
+  opacity: var(--dot-opacity, 0.58);
+  transform: translate(var(--dot-x), var(--dot-y));
 }
-.focus-daily-celebrate-peek {
-  margin-top: 6px;
-  padding: 6px 15px;
-  border: 1px solid var(--border);
-  border-radius: 9px;
-  background: color-mix(in srgb, var(--surface) 60%, transparent);
+.focus-daily-star-dot.dot-far-left { --dot-x: -68px; --dot-y: 7px; --dot-size: 3.5px; --dot-opacity: 0.42; --dot-from-x: -34px; }
+.focus-daily-star-dot.dot-near-left { --dot-x: -39px; --dot-y: -5px; --dot-size: 5px; --dot-from-x: -24px; }
+.focus-daily-star-dot.dot-near-right { --dot-x: 39px; --dot-y: 6px; --dot-size: 4.5px; --dot-from-x: 24px; }
+.focus-daily-star-dot.dot-far-right { --dot-x: 68px; --dot-y: -7px; --dot-size: 3px; --dot-opacity: 0.38; --dot-from-x: 34px; }
+.focus-daily-celebrate-copy {
+  display: grid;
+  justify-items: center;
+  gap: 5px;
+}
+.focus-daily-celebrate strong {
+  color: var(--text);
+  font-size: clamp(22px, 2.6vw, 30px);
+  font-weight: 720;
+  line-height: 1.45;
+  letter-spacing: -0.018em;
+}
+.focus-daily-celebrate-sub {
   color: var(--text-secondary);
-  font: inherit;
-  font-size: 12px;
-  cursor: pointer;
-  transition: background 180ms var(--easing-soft), color 180ms var(--easing-soft);
+  font-size: 13px;
+  line-height: 1.45;
 }
-.focus-daily-celebrate-peek:hover { color: var(--text); background: color-mix(in srgb, var(--text) 6%, transparent); }
-.focus-daily-celebrate.is-celebrating { animation: focus-daily-pop 520ms var(--easing-page) both; }
-.focus-daily-celebrate.is-celebrating .focus-daily-celebrate-burst { animation: focus-daily-burst 860ms var(--easing-soft) both; }
-.focus-daily-celebrate.is-celebrating::before { animation: focus-daily-celebrate-sheen 920ms 80ms var(--easing-soft) both; }
-.focus-daily-celebrate.is-celebrating strong { animation: focus-daily-panel-piece 520ms 130ms var(--easing-page) both; }
-.focus-daily-celebrate.is-celebrating .focus-daily-celebrate-sub { animation: focus-daily-panel-piece 520ms 220ms var(--easing-page) both; }
-.focus-daily-celebrate.is-celebrating .focus-daily-celebrate-peek { animation: focus-daily-panel-piece 520ms 310ms var(--easing-page) both; }
+.focus-daily-review-today {
+  min-width: 132px;
+  height: 42px;
+  margin-top: 12px;
+  padding: 0 22px;
+  border: 1px solid color-mix(in srgb, var(--text) 86%, transparent);
+  border-radius: 999px;
+  background: var(--text);
+  color: var(--surface);
+  font: 650 13px/1 var(--font-ui);
+  cursor: pointer;
+  transition: transform 180ms var(--easing-soft), background 180ms var(--easing-soft), box-shadow 220ms var(--easing-soft);
+}
+.focus-daily-review-today:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 9px 22px color-mix(in srgb, var(--text) 14%, transparent);
+}
+.focus-daily-review-today:active { transform: scale(0.97); }
+.focus-daily-review-today:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--daily-star-gold) 76%, transparent);
+  outline-offset: 4px;
+}
+.focus-daily-celebrate.is-entering .focus-daily-star-main {
+  animation: focus-daily-star-gather-main 780ms 1020ms cubic-bezier(0.2, 1.42, 0.42, 1) both;
+}
+.focus-daily-celebrate.is-entering .focus-daily-star-halo {
+  animation: focus-daily-star-gather-halo 620ms 1250ms var(--easing-soft) both;
+}
+.focus-daily-celebrate.is-entering .focus-daily-star-dot {
+  animation: focus-daily-star-gather-dot 620ms var(--easing-page) both;
+}
+.focus-daily-celebrate.is-entering .focus-daily-star-dot.dot-far-left { animation-delay: 800ms; }
+.focus-daily-celebrate.is-entering .focus-daily-star-dot.dot-near-left { animation-delay: 870ms; }
+.focus-daily-celebrate.is-entering .focus-daily-star-dot.dot-near-right { animation-delay: 910ms; }
+.focus-daily-celebrate.is-entering .focus-daily-star-dot.dot-far-right { animation-delay: 970ms; }
+.focus-daily-celebrate.is-entering strong {
+  animation: focus-daily-celebrate-copy-in 520ms 1360ms var(--easing-page) both;
+}
+.focus-daily-celebrate.is-entering .focus-daily-celebrate-sub {
+  animation: focus-daily-celebrate-copy-in 520ms 1480ms var(--easing-page) both;
+}
+.focus-daily-celebrate.is-entering .focus-daily-review-today {
+  animation: focus-daily-celebrate-copy-in 520ms 1600ms var(--easing-page) both;
+}
 
 .focus-daily-row.is-entering { animation: focus-daily-row-in 440ms var(--easing-page) both; }
 .focus-daily-row.is-removing { overflow: hidden; pointer-events: none; animation: focus-daily-row-out 340ms var(--easing-page) forwards; }
-.focus-daily-row.is-clearing,
-.focus-daily-group.is-clearing {
-  overflow: hidden;
-  animation: focus-daily-slip 540ms var(--easing-page) forwards;
-  animation-delay: var(--daily-clear-delay, 0ms);
+.focus-daily-row.is-complete-pop::after,
+.focus-daily-row.is-reopen-pop::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border: 1px solid transparent;
+  border-radius: inherit;
+  pointer-events: none;
 }
-.focus-daily-row.is-complete-pop { animation: focus-daily-complete-pop 360ms var(--easing-soft) both; }
-.focus-daily-row.is-reopen-pop { animation: focus-daily-reopen-pop 300ms var(--easing-soft) both; }
-@keyframes focus-daily-panel-out {
-  from { opacity: 1; transform: translateX(0); }
-  to { opacity: 0; transform: translateX(calc(100% + 32px)) scale(0.985); }
+.focus-daily-row.is-complete-pop::after {
+  animation: focus-daily-complete-ring 460ms var(--easing-soft) both;
 }
-@keyframes focus-daily-panel-piece {
-  from { opacity: 0; transform: translateY(12px) scale(0.985); }
-  72% { opacity: 1; transform: translateY(-1px) scale(1.002); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
+.focus-daily-row.is-reopen-pop::after {
+  animation: focus-daily-reopen-ring 360ms var(--easing-soft) both;
 }
-@keyframes focus-daily-row-return {
-  from { opacity: 0; transform: translateY(14px) scale(0.985); }
-  68% { opacity: 1; transform: translateY(-1px) scale(1.004); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
-}
-@keyframes focus-daily-slip {
-  0% { opacity: 1; transform: translateY(0) scale(1); filter: blur(0); }
-  32% { opacity: 0.86; transform: translateY(-2px) scale(0.992); }
-  100% {
+@keyframes focus-daily-star-gather-dot {
+  0% {
     opacity: 0;
-    transform: translateY(-12px) scale(0.94);
-    filter: blur(1.4px);
+    transform: translate(calc(var(--dot-x) + var(--dot-from-x)), var(--dot-y)) scale(0.35);
+  }
+  68% {
+    opacity: 0.82;
+    transform: translate(var(--dot-x), var(--dot-y)) scale(1.2);
+  }
+  100% {
+    opacity: var(--dot-opacity);
+    transform: translate(var(--dot-x), var(--dot-y)) scale(1);
   }
 }
-@keyframes focus-daily-pop {
-  from { opacity: 0; transform: translateY(12px) scale(0.9); }
-  64% { opacity: 1; transform: translateY(-2px) scale(1.018); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
+@keyframes focus-daily-star-gather-main {
+  0% { opacity: 0; transform: scale(0.28) rotate(-20deg); }
+  58% { opacity: 1; transform: scale(1.18) rotate(5deg); }
+  78% { transform: scale(0.94) rotate(-2deg); }
+  100% { opacity: 1; transform: scale(1) rotate(0); }
 }
-@keyframes focus-daily-burst {
-  0% { transform: scale(0.4) rotate(-12deg); opacity: 0; box-shadow: 0 0 0 0 color-mix(in srgb, #e0b34d 0%, transparent); }
-  44% { transform: scale(1.16) rotate(4deg); opacity: 1; box-shadow: 0 0 0 12px color-mix(in srgb, #e0b34d 13%, transparent); }
-  100% { transform: scale(1) rotate(0); opacity: 1; box-shadow: 0 0 0 0 color-mix(in srgb, #e0b34d 0%, transparent); }
+@keyframes focus-daily-star-gather-halo {
+  0% { opacity: 0; transform: scale(0.45); }
+  34% { opacity: 0.55; }
+  100% { opacity: 0; transform: scale(1.75); }
 }
-@keyframes focus-daily-celebrate-sheen {
-  0% { opacity: 0; transform: translateX(-30%) skewX(-10deg); }
-  42% { opacity: 1; }
-  100% { opacity: 0; transform: translateX(34%) skewX(-10deg); }
+@keyframes focus-daily-celebrate-copy-in {
+  0% { opacity: 0; transform: translateY(6px); }
+  72% { opacity: 1; transform: translateY(-1px); }
+  100% { opacity: 1; transform: translateY(0); }
 }
-@keyframes focus-daily-celebrate-return {
-  from { opacity: 0; transform: translateY(10px) scale(0.975); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
+@keyframes focus-daily-complete-ring {
+  0% { opacity: 0; border-color: rgba(95, 158, 108, 0); transform: scale(0.995); }
+  38% { opacity: 1; border-color: rgba(95, 158, 108, 0.48); transform: scale(1.004); }
+  100% { opacity: 0; border-color: rgba(95, 158, 108, 0); transform: scale(1.008); }
 }
-@keyframes focus-daily-panel-settle {
-  0% { box-shadow: 0 30px 80px rgba(39, 37, 31, 0.16); }
-  46% {
-    box-shadow:
-      0 34px 86px rgba(39, 37, 31, 0.18),
-      0 0 0 3px color-mix(in srgb, #e0b34d 11%, transparent);
-  }
-  100% { box-shadow: 0 30px 80px rgba(39, 37, 31, 0.16); }
-}
-@keyframes focus-daily-complete-pop {
-  0% { transform: scale(1); background-color: color-mix(in srgb, #5f9e6c 0%, transparent); }
-  28% { transform: scale(1.035); background-color: color-mix(in srgb, #5f9e6c 18%, transparent); }
-  60% { transform: scale(0.992); }
-  100% { transform: scale(1); background-color: color-mix(in srgb, #5f9e6c 0%, transparent); }
-}
-@keyframes focus-daily-reopen-pop {
-  0% { transform: scale(1); }
-  45% { transform: scale(0.992); }
-  100% { transform: scale(1); }
+@keyframes focus-daily-reopen-ring {
+  0% { opacity: 0; border-color: color-mix(in srgb, var(--text) 0%, transparent); }
+  45% { opacity: 0.72; border-color: color-mix(in srgb, var(--text) 18%, transparent); }
+  100% { opacity: 0; border-color: color-mix(in srgb, var(--text) 0%, transparent); }
 }
 @keyframes focus-daily-stat-pop {
-  0% { opacity: 0.58; transform: translateY(2px); }
-  100% { opacity: 1; transform: translateY(0); }
+  0% { opacity: 0.48; }
+  100% { opacity: 1; }
 }
 @keyframes focus-daily-foot-pop {
-  0% { opacity: 0.55; transform: translateY(2px); }
-  100% { opacity: 1; transform: translateY(0); }
+  0% { opacity: 0.55; }
+  100% { opacity: 1; }
 }
 @keyframes focus-daily-row-in {
-  from { opacity: 0; transform: translateY(-8px) scale(0.99); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 @keyframes focus-daily-collapse-item {
   from { opacity: 1; transform: translateY(0) scale(1); }
@@ -10573,8 +10570,7 @@ body.focus-daily-dragging .focus-daily-group-head {
   }
 }
 
-.book-view.focus-zen .focus-daily,
-.book-view.focus-zen .focus-daily-handle { display: none; }
+.book-view.focus-zen .focus-daily { display: none; }
 
 body.start-page[data-start-theme="dark"] .focus-daily {
   background:
@@ -10582,7 +10578,6 @@ body.start-page[data-start-theme="dark"] .focus-daily {
     rgba(24, 26, 27, 0.78);
   box-shadow: 0 30px 80px rgba(0, 0, 0, 0.42);
 }
-body.start-page[data-start-theme="dark"] .focus-daily-handle { background: rgba(24, 26, 27, 0.72); }
 body.start-page[data-start-theme="dark"] .focus-daily-edit,
 body.start-page[data-start-theme="dark"] .focus-daily-edit input,
 body.start-page[data-start-theme="dark"] .focus-daily-add input,
@@ -10699,7 +10694,6 @@ body.start-page[data-start-theme="dark"] .focus-daily-detail-recent span.today {
 }
 
 @media (max-width: 720px) {
-  .focus-daily { top: 70px; right: 10px; bottom: 14px; left: 10px; width: auto; }
   .focus-daily-milestone-shell { padding: 12px; }
   .focus-daily-milestone-dialog { width: min(100%, 560px); max-height: calc(100vh - 24px); padding: 17px; border-radius: 17px; }
   .focus-daily-milestone-row { grid-template-columns: minmax(0, 1fr) 100px 30px; gap: 5px; }
@@ -10708,18 +10702,11 @@ body.start-page[data-start-theme="dark"] .focus-daily-detail-recent span.today {
 }
 @media (prefers-reduced-motion: reduce) {
   .focus-daily,
-  .focus-daily-handle,
-  .focus-daily.is-celebrate-ready,
   .focus-daily.is-revealing .focus-daily-head,
   .focus-daily.is-revealing .focus-daily-row,
   .focus-daily.is-revealing .focus-daily-add,
   .focus-daily.is-revealing .focus-daily-foot,
-  .focus-daily.is-revealing .focus-daily-celebrate:not([hidden]),
-  .focus-daily.is-peeking .focus-daily-row,
-  .focus-daily.is-peeking .focus-daily-add,
-  .focus-daily.is-peeking .focus-daily-foot,
-  .focus-daily.is-completing .focus-daily-add,
-  .focus-daily.is-completing .focus-daily-foot,
+  .focus-daily.is-revealing .focus-daily-celebrate,
   .focus-daily-goal,
   .focus-daily-goal-shell,
   .focus-daily-goal::after,
@@ -10747,25 +10734,544 @@ body.start-page[data-start-theme="dark"] .focus-daily-detail-recent span.today {
   .focus-daily-row.is-removing,
   .focus-daily-row.is-complete-pop,
   .focus-daily-row.is-reopen-pop,
-  .focus-daily-stat.is-updating,
+  .focus-daily-row.is-complete-pop::after,
+  .focus-daily-row.is-reopen-pop::after,
   .focus-daily-foot.is-updating,
   .focus-daily-group-progress.is-updating,
-  .focus-daily-celebrate.is-celebrating,
-  .focus-daily-celebrate.is-celebrating::before,
-  .focus-daily-celebrate.is-celebrating strong,
-  .focus-daily-celebrate.is-celebrating .focus-daily-celebrate-sub,
-  .focus-daily-celebrate.is-celebrating .focus-daily-celebrate-peek,
-  .focus-daily-celebrate.is-celebrating .focus-daily-celebrate-burst,
+  .focus-daily-celebrate.is-visible,
+  .focus-daily-celebrate.is-entering,
+  .focus-daily-celebrate.is-leaving,
+  .focus-daily-celebrate-inner,
+  .focus-daily-celebrate.is-entering .focus-daily-star-dot,
+  .focus-daily-celebrate.is-entering .focus-daily-star-main,
+  .focus-daily-celebrate.is-entering .focus-daily-star-halo,
+  .focus-daily-celebrate.is-entering strong,
+  .focus-daily-celebrate.is-entering .focus-daily-celebrate-sub,
+  .focus-daily-celebrate.is-entering .focus-daily-review-today,
+  .focus-daily-scroll,
   .focus-daily-detail-shell,
   .focus-daily-detail,
   .focus-daily-detail-calendar-head strong.is-month-settling,
   .focus-daily-detail-grid,
   .focus-daily-detail-day,
-  .focus-daily-row.is-clearing,
-  .focus-daily.is-closing,
   .focus-daily-history.is-closing,
   .focus-daily-group.is-collapsing > .focus-daily-group-children > .focus-daily-group-children-inner > .focus-daily-row,
   .focus-daily-group.is-collapsing > .focus-daily-group-children > .focus-daily-group-children-inner > .focus-daily-group { transition: none !important; animation: none !important; }
+}
+
+/* ── 专注页双视图 V2 · 卡片清单与分层交叉过渡 ───────────────────── */
+.focus-timer-view[hidden],
+.focus-daily-view[hidden],
+.focus-daily-composer[hidden],
+.focus-daily-skeleton[hidden] { display: none !important; }
+
+.focus-embedded {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
+  align-content: stretch;
+  overflow: hidden;
+}
+.focus-embedded > .focus-timer-view,
+.focus-embedded > .focus-daily-view {
+  grid-area: 1 / 1;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow-x: hidden;
+}
+.focus-embedded > .focus-timer-view {
+  overflow-y: auto;
+  scrollbar-gutter: auto;
+}
+.focus-embedded > .focus-timer-view {
+  /* 桌面端视觉重心略向右下落；使用相对定位保持入场前后同一基准，
+     不把位移写进动画或 transform，避免动画收尾时重新栅格化跳回。 */
+  left: clamp(10px, 0.75vw, 16px);
+  top: clamp(8px, 1vh, 12px);
+}
+.focus-embedded.focus-view-transition > .focus-timer-view,
+.focus-embedded.focus-view-transition > .focus-daily-view { align-self: start; }
+.focus-timer-view.is-view-exiting,
+.focus-daily-view.is-view-exiting {
+  pointer-events: none;
+  animation: focus-view-layer-out 160ms var(--easing-soft) both;
+}
+.focus-timer-view.is-view-entering,
+.focus-daily-view.is-view-entering {
+  animation: focus-view-layer-in 420ms 110ms var(--easing-page) both;
+}
+@keyframes focus-view-layer-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+@keyframes focus-view-layer-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.focus-daily.focus-daily-view {
+  position: relative;
+  inset: auto;
+  z-index: auto;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  box-sizing: border-box;
+  margin: 0 auto;
+  padding: 0;
+  display: block;
+  overflow: hidden;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  opacity: 1;
+  pointer-events: auto;
+  transform: none;
+  transition: none;
+  overscroll-behavior: contain;
+}
+.focus-daily-scroll {
+  position: relative;
+  width: min(800px, 100%);
+  height: 100%;
+  min-height: 0;
+  margin: 0 auto;
+  padding: clamp(30px, 7vh, 68px) 0 72px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  opacity: 1;
+  transform: none;
+  transition: opacity 260ms var(--easing-soft), transform 440ms var(--easing-page);
+}
+.focus-daily-scroll::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none;
+}
+.focus-daily-scroll:focus { outline: none; }
+.focus-daily-view.is-celebration-open .focus-daily-scroll {
+  opacity: 0;
+  transform: scale(0.994);
+  pointer-events: none;
+  transition-delay: 100ms, 100ms;
+}
+.focus-daily-view.is-celebration-entering .focus-daily-scroll {
+  opacity: 1;
+  transform: none;
+  transition: none;
+}
+.focus-daily-view.is-celebration-entering .focus-daily-row,
+.focus-daily-view.is-celebration-entering .focus-daily-group > .focus-daily-group-head,
+.focus-daily-view.is-celebration-entering .focus-daily-empty {
+  animation: focus-daily-celebration-card-out 840ms cubic-bezier(0.2, 0.72, 0.22, 1) both;
+  animation-delay: calc(var(--daily-exit-order, 0) * 48ms);
+  pointer-events: none;
+}
+.focus-daily-view.is-celebration-entering .focus-daily-head {
+  animation: focus-daily-celebration-support-out 720ms cubic-bezier(0.2, 0.72, 0.22, 1) both;
+  animation-delay: calc(130ms + var(--daily-exit-tail, 0) * 48ms);
+}
+.focus-daily-view.is-celebration-entering .focus-daily-foot,
+.focus-daily-view.is-celebration-entering .focus-daily-composer {
+  animation: focus-daily-celebration-support-out 560ms cubic-bezier(0.2, 0.72, 0.22, 1) both;
+}
+.focus-daily-view.is-celebration-leaving .focus-daily-scroll {
+  opacity: 1;
+  transform: none;
+  pointer-events: none;
+  transition-delay: 35ms, 35ms;
+}
+@keyframes focus-daily-celebration-card-out {
+  0%, 35% { opacity: 1; transform: translateY(0) scale(1); }
+  72% { opacity: 0.48; transform: translateY(-3px) scale(0.994); }
+  100% { opacity: 0; transform: translateY(-9px) scale(0.984); }
+}
+@keyframes focus-daily-celebration-support-out {
+  0%, 22% { opacity: 1; transform: translateY(0); }
+  72% { opacity: 0.38; }
+  100% { opacity: 0; transform: translateY(-7px); }
+}
+.focus-daily-view .focus-daily-head {
+  align-items: center;
+  padding: 0 5px 14px;
+}
+.focus-daily-view .focus-daily-head h1 {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin: 4px 0 0;
+  color: var(--text);
+  font-size: clamp(34px, 4vw, 44px);
+  font-weight: 720;
+  line-height: 1.05;
+  letter-spacing: -0.035em;
+}
+.focus-daily-view .focus-daily-head h1 span {
+  color: var(--text-tertiary);
+  font-size: 14px;
+  font-weight: 580;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+.focus-daily-create {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--text-tertiary);
+  font: 300 28px/1 var(--font-ui);
+  cursor: pointer;
+  transition: color 180ms var(--easing-soft), background 180ms var(--easing-soft), transform 180ms var(--easing-soft);
+}
+.focus-daily-create:disabled { opacity: 0.38; cursor: wait; }
+.focus-daily-create:hover,
+.focus-daily-create[aria-expanded="true"] {
+  color: var(--text);
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+}
+.focus-daily-create[aria-expanded="true"] { transform: rotate(45deg); }
+.focus-daily-create:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 72%, transparent);
+  outline-offset: 3px;
+}
+
+.focus-daily-content {
+  position: relative;
+  display: grid;
+  flex: 0 0 auto;
+  min-height: 150px;
+}
+.focus-daily-content > .focus-daily-list,
+.focus-daily-content > .focus-daily-skeleton { grid-area: 1 / 1; }
+.focus-daily-view .focus-daily-list {
+  flex: 0 0 auto;
+  min-height: 150px;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  overflow: visible;
+  opacity: 1;
+  transition: opacity 180ms var(--easing-soft);
+}
+.focus-daily-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+  pointer-events: none;
+}
+.focus-daily-skeleton span {
+  display: block;
+  height: 82px;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: 16px;
+  background:
+    linear-gradient(105deg, transparent 30%, color-mix(in srgb, var(--surface) 82%, transparent) 48%, transparent 66%),
+    color-mix(in srgb, var(--surface) 84%, transparent);
+  background-size: 220% 100%, 100% 100%;
+  animation: focus-daily-skeleton-sheen 1.5s var(--easing-soft) infinite;
+}
+.focus-daily-skeleton span:nth-child(2) { opacity: 0.78; }
+.focus-daily-skeleton span:nth-child(3) { opacity: 0.56; }
+.focus-daily-view.is-loading .focus-daily-list { opacity: 0; pointer-events: none; }
+.focus-daily-view.is-data-revealing .focus-daily-skeleton {
+  animation: focus-daily-skeleton-out 260ms var(--easing-soft) both;
+}
+@keyframes focus-daily-skeleton-sheen {
+  from { background-position: 120% 0, 0 0; }
+  to { background-position: -120% 0, 0 0; }
+}
+@keyframes focus-daily-skeleton-out {
+  to { opacity: 0; transform: translateY(-3px); }
+}
+.focus-daily-view .focus-daily-empty {
+  margin: 20px 0;
+  padding: 25px 22px;
+  border: 1px dashed color-mix(in srgb, var(--border-strong) 74%, transparent);
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+  text-align: center;
+  font-size: 13px;
+}
+.focus-daily-view .focus-daily-row {
+  align-items: center;
+  gap: 13px;
+  width: calc(100% - min(var(--daily-depth, 0), 5) * 18px);
+  min-height: 78px;
+  margin-left: calc(min(var(--daily-depth, 0), 5) * 18px);
+  padding: 15px 14px 15px 16px;
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--surface) 94%, white 6%);
+  box-shadow: 0 2px 5px rgba(35, 33, 29, 0.025), 0 9px 24px rgba(35, 33, 29, 0.025);
+  transition: border-color 190ms var(--easing-soft), background 190ms var(--easing-soft),
+              box-shadow 220ms var(--easing-soft), opacity 200ms var(--easing-soft),
+              transform 220ms var(--easing-soft);
+}
+.focus-daily-view .focus-daily-row:hover,
+.focus-daily-view .focus-daily-row:focus-within {
+  border-color: color-mix(in srgb, var(--border-strong) 82%, transparent);
+  background: color-mix(in srgb, var(--surface) 98%, white 2%);
+  box-shadow: 0 7px 20px rgba(35, 33, 29, 0.07);
+  transform: translateY(-1px);
+}
+.focus-daily-view .focus-daily-row.is-done {
+  background: color-mix(in srgb, var(--surface) 91%, var(--text) 1%);
+}
+.focus-daily-view .focus-daily-row.is-done .focus-daily-main { opacity: 0.78; }
+.focus-daily-view .focus-daily-row.is-done .focus-daily-stat { opacity: 1; }
+.focus-daily-view .focus-daily-row.is-done:hover .focus-daily-main,
+.focus-daily-view .focus-daily-row.is-done:focus-within .focus-daily-main { opacity: 0.92; }
+.focus-daily-view .focus-daily-row.is-syncing {
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--border));
+}
+.focus-daily-view .focus-daily-check { margin-top: 0; }
+.focus-daily-view .focus-daily-main { align-self: center; }
+.focus-daily-view .focus-daily-main {
+  transition: opacity 180ms var(--easing-soft);
+}
+.focus-daily-view .focus-daily-name {
+  font-size: 16px;
+  font-weight: 620;
+  line-height: 1.45;
+}
+.focus-daily-view .focus-daily-stat {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+}
+.focus-daily-view .focus-daily-main > .focus-daily-goal-shell {
+  display: block;
+  max-width: 420px;
+  margin-top: 7px;
+}
+.focus-daily-view .focus-daily-main > .focus-daily-edit { display: flex; }
+.focus-daily-view .focus-daily-history-btn,
+.focus-daily-view .focus-daily-menu { margin-top: 0; }
+.focus-daily-view .focus-daily-group { gap: 8px; }
+.focus-daily-view .focus-daily-group-head {
+  min-height: 46px;
+  margin-top: 20px;
+  margin-left: calc(min(var(--daily-depth, 0), 5) * 18px);
+  padding: 8px 8px 8px 5px;
+  border-radius: 12px;
+}
+.focus-daily-view .focus-daily-list > .focus-daily-group:first-child > .focus-daily-group-head {
+  margin-top: 0;
+}
+.focus-daily-view .focus-daily-group-head .focus-daily-group-name {
+  font-size: 20px;
+  font-weight: 680;
+  letter-spacing: -0.02em;
+}
+.focus-daily-view .focus-daily-group-progress {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text) 5%, transparent);
+}
+.focus-daily-view .focus-daily-group-children-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 4px;
+}
+.focus-daily-view .focus-daily-group-children-inner::before {
+  left: calc(13px + min(var(--daily-depth, 0), 5) * 18px);
+}
+
+.focus-daily.is-revealing .focus-daily-head {
+  animation: focus-daily-heading-spring-in 600ms 40ms var(--easing-page) both;
+}
+.focus-daily.is-revealing .focus-daily-group > .focus-daily-group-head,
+.focus-daily.is-revealing .focus-daily-row,
+.focus-daily.is-revealing .focus-daily-empty {
+  animation: focus-daily-card-spring-in 680ms var(--easing-page) both;
+  animation-delay: calc(150ms + var(--daily-row-index, 0) * 72ms);
+}
+.focus-daily.is-revealing .focus-daily-foot {
+  animation: focus-daily-support-spring-in 560ms 390ms var(--easing-page) both;
+}
+@keyframes focus-daily-heading-spring-in {
+  0% { opacity: 0; transform: translateY(12px); }
+  68% { opacity: 1; transform: translateY(-2px); }
+  84% { transform: translateY(1px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+@keyframes focus-daily-card-spring-in {
+  0% { opacity: 0; transform: translateY(18px) scale(0.975); }
+  58% { opacity: 1; transform: translateY(-3px) scale(1.012); }
+  78% { transform: translateY(1px) scale(0.997); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes focus-daily-support-spring-in {
+  0% { opacity: 0; transform: translateY(9px); }
+  72% { opacity: 1; transform: translateY(-1px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+.focus-daily-ghost {
+  border: 1px solid color-mix(in srgb, var(--border-strong) 84%, transparent);
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--surface) 97%, white 3%);
+  box-shadow: 0 18px 42px rgba(35, 33, 29, 0.16);
+}
+
+.focus-daily-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 4px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--surface) 94%, white 6%);
+  box-shadow: 0 7px 22px rgba(35, 33, 29, 0.045);
+  animation: focus-daily-edit-in 260ms var(--easing-page) both;
+}
+.focus-daily-composer.is-pending { opacity: 0.72; }
+.focus-daily-view .focus-daily-compose,
+.focus-daily-view .focus-daily-add { width: 100%; }
+.focus-daily-view .focus-daily-compose-target { max-width: min(320px, 55vw); }
+.focus-daily-view .focus-daily-add input { background: color-mix(in srgb, var(--surface) 82%, transparent); }
+.focus-daily-view .focus-daily-foot {
+  min-height: 18px;
+  margin-top: 2px;
+  text-align: left;
+}
+.focus-daily-view .focus-daily-foot[hidden] { display: none; }
+.focus-daily-view .focus-daily-celebrate {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+}
+
+body.start-page[data-start-theme="dark"] .focus-daily.focus-daily-view {
+  background: transparent;
+  box-shadow: none;
+}
+body.start-page[data-start-theme="dark"] .focus-daily-celebrate {
+  --daily-star-gold: #e0b660;
+  background:
+    radial-gradient(circle at 50% 45%, rgba(224, 182, 96, 0.08), transparent 34%),
+    rgba(18, 20, 21, 0.97);
+}
+body.start-page[data-start-theme="dark"] .focus-daily-review-today {
+  border-color: rgba(242, 241, 237, 0.9);
+  background: #f2f1ed;
+  color: #151716;
+}
+body.start-page[data-start-theme="dark"] .focus-daily-view .focus-daily-row,
+body.start-page[data-start-theme="dark"] .focus-daily-ghost {
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.045);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.13);
+}
+body.start-page[data-start-theme="dark"] .focus-daily-view .focus-daily-row:hover,
+body.start-page[data-start-theme="dark"] .focus-daily-view .focus-daily-row:focus-within {
+  border-color: rgba(255, 255, 255, 0.17);
+  background: rgba(255, 255, 255, 0.065);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.23);
+}
+body.start-page[data-start-theme="dark"] .focus-daily-composer {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.045);
+}
+body.start-page[data-start-theme="dark"] .focus-daily-skeleton span {
+  border-color: rgba(255, 255, 255, 0.08);
+  background:
+    linear-gradient(105deg, transparent 30%, rgba(255, 255, 255, 0.045) 48%, transparent 66%),
+    rgba(255, 255, 255, 0.025);
+  background-size: 220% 100%, 100% 100%;
+}
+
+@media (max-width: 900px) {
+  .focus-embedded > .focus-timer-view {
+    left: 0;
+    top: 0;
+  }
+}
+@media (max-width: 720px) {
+  .focus-daily.focus-daily-view {
+    position: relative;
+    inset: auto;
+    width: 100%;
+    padding: 0;
+  }
+  .focus-daily-scroll {
+    width: 100%;
+    padding: 22px 0 48px;
+  }
+  .focus-daily-view .focus-daily-head h1 { font-size: 30px; }
+  .focus-daily-view .focus-daily-group-head .focus-daily-group-name {
+    font-size: 18px;
+  }
+  .focus-daily-view .focus-daily-row {
+    width: calc(100% - min(var(--daily-depth, 0), 5) * 11px);
+    margin-left: calc(min(var(--daily-depth, 0), 5) * 11px);
+    padding-inline: 13px 10px;
+  }
+  .focus-daily-view .focus-daily-group-head {
+    margin-left: calc(min(var(--daily-depth, 0), 5) * 11px);
+  }
+  .focus-daily-view .focus-daily-celebrate {
+    padding: 30px 12px;
+  }
+  .focus-daily-view .focus-daily-celebrate-inner {
+    min-height: 220px;
+    padding: 18px 8px;
+  }
+  .focus-daily-view .focus-daily-star-gather {
+    width: 140px;
+    height: 54px;
+    flex-basis: 54px;
+  }
+  .focus-daily-view .focus-daily-star-dot.dot-far-left { --dot-x: -54px; }
+  .focus-daily-view .focus-daily-star-dot.dot-near-left { --dot-x: -31px; }
+  .focus-daily-view .focus-daily-star-dot.dot-near-right { --dot-x: 31px; }
+  .focus-daily-view .focus-daily-star-dot.dot-far-right { --dot-x: 54px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .focus-timer-view.is-view-exiting,
+  .focus-daily-view.is-view-exiting,
+  .focus-timer-view.is-view-entering,
+  .focus-daily-view.is-view-entering,
+  .focus-daily.is-revealing .focus-daily-head,
+  .focus-daily.is-revealing .focus-daily-group > .focus-daily-group-head,
+  .focus-daily.is-revealing .focus-daily-row,
+  .focus-daily.is-revealing .focus-daily-foot,
+  .focus-daily.is-revealing .focus-daily-celebrate,
+  .focus-daily-celebrate,
+  .focus-daily-celebrate-inner,
+  .focus-daily-celebrate.is-entering .focus-daily-star-dot,
+  .focus-daily-celebrate.is-entering .focus-daily-star-main,
+  .focus-daily-celebrate.is-entering .focus-daily-star-halo,
+  .focus-daily-celebrate.is-entering strong,
+  .focus-daily-celebrate.is-entering .focus-daily-celebrate-sub,
+  .focus-daily-celebrate.is-entering .focus-daily-review-today,
+  .focus-daily-view.is-celebration-entering .focus-daily-head,
+  .focus-daily-view.is-celebration-entering .focus-daily-row,
+  .focus-daily-view.is-celebration-entering .focus-daily-group > .focus-daily-group-head,
+  .focus-daily-view.is-celebration-entering .focus-daily-empty,
+  .focus-daily-view.is-celebration-entering .focus-daily-foot,
+  .focus-daily-view.is-celebration-entering .focus-daily-composer,
+  .focus-daily-scroll,
+  .focus-daily-skeleton span,
+  .focus-daily-view.is-data-revealing .focus-daily-skeleton,
+  .focus-daily-create,
+  .focus-daily-composer { transition: none !important; animation: none !important; }
 }
 
 body.start-page[data-start-theme="dark"] .focus-workbench {
@@ -14322,11 +14828,33 @@ body.start-page[data-start-theme="dark"] .start-page-note.is-selected {
   color: var(--text-tertiary);
   font-variant-numeric: tabular-nums;
 }
+.recent-item-duration {
+  position: absolute;
+  right: 20px;
+  bottom: 16px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  opacity: 0;
+  transform: translateX(5px);
+  pointer-events: none;
+  transition: opacity 180ms var(--easing-soft), transform 180ms var(--easing-soft);
+}
+.recent-item:hover .recent-item-duration,
+.recent-item:focus-visible .recent-item-duration,
+.recent-item.file-selected .recent-item-duration {
+  opacity: 1;
+  transform: translateX(0);
+}
 .book-page .recent-item-meta { gap: 0; }
 .book-page .recent-item-stats::before {
   content: "·";
   margin: 0 8px;
   color: var(--text-tertiary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .recent-item-duration { transition: none; }
 }
 
 .recent-item-where {

--- a/tests/canvas-activity-contract.js
+++ b/tests/canvas-activity-contract.js
@@ -1,0 +1,63 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const read = (...parts) => fs.readFileSync(path.join(root, ...parts), 'utf8');
+const editor = read('assets', 'editor.js');
+const editorHtml = read('assets', 'editor.html');
+const start = read('assets', 'start.js');
+const study = read('assets', 'study.js');
+const graph = read('assets', 'study-graph.js');
+const styles = read('assets', 'styles.css');
+const i18n = read('assets', 'i18n.js');
+const backend = read('app.py');
+
+assert(!editorHtml.includes('data-role="canvas-work-time"'),
+  '累计时长不应占用编辑器标题区');
+assert(start.includes('recent-item-duration') && start.includes('canvasActivitySec'),
+  '最近画布列表必须展示每张画布累计时长');
+[
+  "fetch('/api/canvas-activity'",
+  "document.hasFocus()",
+  "window.addEventListener('blur'",
+  "document.addEventListener('visibilitychange'",
+  "window.addEventListener('pagehide'",
+  'keepalive: !!keepalive',
+  '30000',
+].forEach((needle) => assert(editor.includes(needle), '前台计时契约缺失：' + needle));
+
+assert(study.includes("let cadenceLens = 'canvas';"), '新版年度足迹必须默认画布镜头');
+assert(study.includes("localStorage.getItem('canvas:cadenceLens:v2')"), '必须使用独立 v2 镜头偏好');
+assert(study.includes('data-lens="canvas"') && study.indexOf('data-lens="canvas"') < study.indexOf('data-lens="complete"'),
+  '画布按钮必须排在完成按钮左侧');
+assert(study.includes('const clv = cadenceFocusLevel(cmin);'), '画布分钟必须使用七档时长映射');
+[15, 30, 60, 120, 180, 300].forEach((limit) =>
+  assert(study.includes('min <= ' + limit), '画布热力图缺少分钟边界：' + limit));
+[
+  'payload.canvasDays',
+  'payload.canvasEntries',
+  'payload.canvasStats',
+  'payload.canvasGraph',
+  'payload.canvasOverviewGraph',
+].forEach((needle) => assert(study.includes(needle), '画布活跃页字段未消费：' + needle));
+
+assert(styles.includes('.cadence-lens-canvas .cadence-cell:not(.is-future).cadence-cl7'),
+  '画布热力图必须提供第七档样式');
+assert(graph.includes("data.kind === 'canvas'"), '星图必须识别画布数据结构');
+assert(graph.includes('累计 '), '画布星图悬停必须展示累计时长');
+assert(i18n.includes("'画布使用时间星图': 'Canvas time constellation'")
+  && i18n.includes('canvas') && i18n.includes('canvases'),
+  '画布足迹的静态和动态文案必须提供英文');
+
+[
+  'CANVAS_ACTIVITY_FILE',
+  '"/api/canvas-activity"',
+  '"canvasDays"',
+  '"canvasEntries"',
+  '"canvasStats"',
+  '"canvasGraph"',
+  '"canvasOverviewGraph"',
+].forEach((needle) => assert(backend.includes(needle), '后端画布活动契约缺失：' + needle));
+
+console.log('canvas activity contract checks passed');

--- a/tests/daily-goal-contract.js
+++ b/tests/daily-goal-contract.js
@@ -41,16 +41,17 @@ const backend = fs.readFileSync(path.join(root, 'app.py'), 'utf8');
   'task.totalDays = want ? prevTotalDays + 1 : Math.max(0, prevTotalDays - 1)',
   'milestoneIds: crossedMilestones',
   'refreshDailyRowStats(task, goalMotion)',
-  'task.totalDays = prevTotalDays',
-  'waitForGoal: want && targetDays > 0,',
-  'opts.waitForMilestone ? 1420',
-  'waitForMilestone: want && crossedMilestones.length > 0',
+  'Object.assign(current, JSON.parse(JSON.stringify(state.confirmedTask)))',
+  'dailyCelebrationCheck();',
   'function refreshDailyDetailGoal(task, options)',
   "dailyDetailBlock(T('累计目标'))",
   "dailyDetailBlock('今日进度')",
   "event.target.closest('.focus-daily-milestone')",
   "window.matchMedia('(pointer: coarse)').matches",
 ].forEach((needle) => assert(focus.includes(needle), 'missing frontend daily-goal contract: ' + needle));
+
+assert(!focus.includes('function startDailyClear('),
+  'completed daily tasks must remain visible instead of clearing the list');
 
 assert(!focus.includes("bar.className = 'focus-daily-bar'"),
   'daily cards must no longer render the old per-day minute bar');

--- a/tests/focus-view-contract.js
+++ b/tests/focus-view-contract.js
@@ -1,0 +1,327 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const read = (...parts) => fs.readFileSync(path.join(root, ...parts), 'utf8');
+const html = read('assets', 'index.html');
+const focus = read('assets', 'focus.js');
+const start = read('assets', 'start.js');
+const styles = read('assets', 'styles.css');
+const i18n = read('assets', 'i18n.js');
+
+assert(html.includes('<link rel="preload" href="focus.js" as="script">')
+  && html.includes('window.RelatumBoot.focus = {')
+  && html.includes("daily: preloadJson('/api/daily')")
+  && html.includes("sessions: preloadJson('/api/focus')")
+  && html.includes("study: preloadJson('/api/study')"),
+  'the start document must begin loading the Focus module and its small datasets during parsing');
+
+[
+  'data-role="focus-timer-view"',
+  'class="focus-daily focus-daily-view"',
+  'data-role="focus-daily-count"',
+  'data-action="daily-compose-toggle"',
+  'data-role="focus-daily-skeleton"',
+  'class="focus-daily-content"',
+  'class="focus-daily-scroll" data-role="focus-daily-scroll" tabindex="-1"',
+  'data-role="focus-daily-composer" hidden',
+  'data-phase="hidden" aria-hidden="true"',
+  'class="focus-daily-celebrate-inner"',
+  'class="focus-daily-star-gather"',
+  'class="focus-daily-star-halo"',
+  'class="focus-daily-star-dot dot-far-left"',
+  'class="focus-daily-star-dot dot-near-left"',
+  'class="focus-daily-star-main"',
+  'class="focus-daily-star-dot dot-near-right"',
+  'class="focus-daily-star-dot dot-far-right"',
+  'class="focus-daily-celebrate-copy"',
+  'aria-atomic="true"',
+  'id="focus-daily-celebrate-title">今日清单已全部完成</strong>',
+  'class="focus-daily-review-today" data-action="daily-review-today">回顾今日</button>',
+].forEach((needle) => assert(html.includes(needle), 'missing focus dual-view markup: ' + needle));
+
+[
+  'focus-daily-handle',
+  'data-action="daily-toggle"',
+  'data-action="daily-close"',
+  'data-action="daily-peek"',
+  'focus-daily-celebrate-burst',
+  'focus-daily-star-trail',
+  'focus-daily-star-path',
+  'focus-daily-star-particles',
+  '每日任务（Tab 开合）',
+].forEach((needle) => assert(!html.includes(needle), 'legacy daily sidebar markup remains: ' + needle));
+
+[
+  "const VIEW_MODE_KEY = 'focus:viewMode'",
+  "const DAILY_REVIEWED_KEY = 'focus:dailyReviewedDate'",
+  "localStorage.getItem(VIEW_MODE_KEY) === 'daily'",
+  "localStorage.setItem(VIEW_MODE_KEY, viewMode)",
+  'function sessionLocksView()',
+  'return !!(running || pendingSession);',
+  "toast('请先完成收尾或重置当前专注段，再查看每日任务')",
+  'function toggleViewMode()',
+  'function showTimerView(options)',
+  'function prepareFocusActivation(options)',
+  'function deactivateFocusView()',
+  'prepareActivate(options)',
+  'deactivate: deactivateFocusView',
+  'const controller = typeof AbortController',
+  "if (String(path || '').startsWith('/api/daily-')) cancelDailyRead();",
+  'if (requestId !== dailyRequestSeq) return false;',
+  'nextSignature !== dailySignature',
+  'const dailyToggleStates = new Map();',
+  'function drainDailyToggle(id, state)',
+  'if (dailyCreatePending) return;',
+  'const replayCleanupTimers = new WeakMap();',
+  'let dailyCelebrateMotionTimer = 0;',
+  'let dailyCelebrateHideTimer = 0;',
+  'let dailyCelebrateGeneration = 0;',
+  "let dailyCelebratePhase = 'hidden';",
+  'let dailyCelebrateFocusTimer = 0;',
+  'let dailyCelebrateReturnId = \'\';',
+  'const generation = ++dailyCelebrateGeneration;',
+  'function updateDailyCelebrateCopy()',
+  'function commitDailyCelebratePhase(phase)',
+  'function dailyReviewedToday()',
+  'function setDailyReviewedToday(reviewed)',
+  'function reviewDailyCelebration()',
+  "dailyScrollEl.toggleAttribute('inert', blocked);",
+  "dailyScrollEl.setAttribute('aria-hidden', blocked ? 'true' : 'false');",
+  "dailyRoot.classList.toggle('is-celebration-entering', phase === 'entering');",
+  "element.style.setProperty('--daily-exit-order'",
+  "if (action.dataset.action === 'daily-review-today') { reviewDailyCelebration(); return; }",
+  "if (dailyCelebratePhase === 'entering' || dailyCelebratePhase === 'visible') return;",
+  "dailyCelebrateEl.classList.add('is-visible', 'is-entering');",
+  "commitDailyCelebratePhase('entering');",
+  "commitDailyCelebratePhase('visible');",
+  "commitDailyCelebratePhase('leaving');",
+  "commitDailyCelebratePhase('hidden');",
+  "dailyCelebrateEl.classList.add('is-leaving');",
+  "T('今日清单已全部完成')",
+  "T('今天做完了 ' + count + ' 件事'",
+  'let dailyRevealWaitingForData = false;',
+  'function armDailyViewEntranceCleanup()',
+  "check.setAttribute('data-i18n-source-aria-label', checkLabel);",
+  "loadDaily({ reveal: true, entrance: false });",
+  "if (edit) edit.classList.remove('is-saving');",
+  "dailyListEl.querySelectorAll('.is-dragging, .is-drag-subtree')",
+  "showTimerView({ persist: false, animate: false });",
+  "if (action.dataset.action === 'daily-detail-bind' && dailyDetailTaskId)",
+  'toggleMode: toggleViewMode',
+  'showTimer(options) { return showTimerView(options); }',
+].forEach((needle) => assert(focus.includes(needle), 'missing focus view-state contract: ' + needle));
+
+assert(start.includes("focusActive && window.CanvasFocus && typeof window.CanvasFocus.toggleMode === 'function'"),
+  'active Focus spine click must toggle the internal view');
+assert(start.includes('window.CanvasFocus.toggleMode();'),
+  'Focus spine must delegate view switching to CanvasFocus');
+assert(start.includes("typeof window.CanvasFocus.prepareActivate === 'function'"),
+  'Focus must prepare its internal view before the outer page becomes visible');
+assert(start.indexOf('window.CanvasFocus.prepareActivate(options || {});') < start.indexOf("showView('focus');"),
+  'Focus preparation must run before the outer page transition');
+assert(start.includes("setFocusActive(true, { forceTimer: true });"),
+  'external Focus entries must force the timer before the page transition');
+assert(start.includes("typeof window.CanvasFocus.deactivate === 'function'"),
+  'leaving Focus must cancel transient view work');
+assert(start.includes("document.addEventListener('canvasfocus:ready', finishPendingFocusActivation);"),
+  'the start page must replay a first Focus activation once its deferred module is ready');
+assert(start.includes('pendingFocusActivation = { options: Object.assign({}, options || {}) };')
+  && start.includes('window.CanvasFocus.prepareActivate(pending.options || {});')
+  && start.includes('window.CanvasFocus.activate();'),
+  'a pre-ready Focus request must preserve its options and perform one complete activation');
+assert(start.includes("focusRoot.dataset.pendingForceTimer = options && options.forceTimer ? '1' : '0';")
+  && focus.includes("root.dataset.pendingForceTimer === '1' || sessionLocksView()"),
+  'pre-ready external entries must force the timer before the Focus module exposes its first frame');
+assert(focus.includes("document.dispatchEvent(new CustomEvent('canvasfocus:ready'));"),
+  'CanvasFocus must announce readiness after publishing its complete public interface');
+assert(focus.includes('function preloadFocusView()')
+  && focus.includes('loadDaily({ source: bootFocusData.daily, reveal: false, entrance: false, quiet: true })')
+  && focus.includes('preloadFocusView().finally(() => {')
+  && focus.indexOf('window.CanvasFocus = canvasFocusApi;') > focus.indexOf('preloadFocusView().finally(() => {'),
+  'CanvasFocus must hydrate hidden data before exposing itself as ready');
+const pendingFocusBranch = start.slice(
+  start.indexOf('pendingFocusActivation = { options: Object.assign({}, options || {}) };'),
+  start.indexOf('function runWhenCanvasFocusReady(action)'),
+);
+assert(!pendingFocusBranch.includes("showView('focus');"),
+  'a pre-ready first click must keep the previous page visible instead of showing an empty Focus shell');
+const pendingFocusFinish = start.slice(
+  start.indexOf('function finishPendingFocusActivation()'),
+  start.indexOf("document.addEventListener('canvasfocus:ready'"),
+);
+assert(pendingFocusFinish.indexOf('window.CanvasFocus.prepareActivate(pending.options || {});')
+    < pendingFocusFinish.indexOf("showView('focus');")
+  && pendingFocusFinish.indexOf("showView('focus');")
+    < pendingFocusFinish.indexOf('window.CanvasFocus.activate();'),
+  'the delayed first flip must prepare hydrated DOM, then turn the page, then play one entrance');
+assert(start.includes('runWhenCanvasFocusReady((focus) => {')
+  && start.includes('if (event.detail.day && focus.showDay)')
+  && start.includes('if (focus.prepareTask) focus.prepareTask'),
+  'calendar and study Focus intents must survive the same first-load readiness race');
+assert(!focus.includes("event.key === 'Tab' && !event.ctrlKey"),
+  'Tab must no longer toggle a daily sidebar');
+assert(!styles.includes('.focus-daily-handle'),
+  'legacy daily sidebar handle styles must be removed');
+assert(!styles.includes('.focus-daily.is-open'),
+  'legacy daily sidebar open-state styles must be removed');
+assert(!focus.includes('function startDailyClear('),
+  'all-complete state must not clear the daily list');
+assert(focus.includes('dailyCelebrationCheck({ animate: !!opts.celebrate && !opts.initial });'),
+  'all-complete feedback must remain non-destructive and use the shared state entry');
+assert(focus.includes('dailyWasAllDone = allDailyDone();')
+  && focus.includes('const became = allDone && !dailyWasAllDone;')
+  && focus.includes('renderDaily({ celebrate: true });'),
+  'initial all-complete data must render statically while an incomplete-to-complete interaction celebrates once');
+assert(focus.includes('if (!dailyTasks.length || (allDailyDone() && !dailyReviewedToday()))')
+  && focus.includes('dailyFootEl.hidden = true;'),
+  'the ordinary today summary must hide behind an unreviewed completion screen and return after review');
+assert(focus.includes("dailyFootEl.hidden = dailyCelebratePhase !== 'hidden';")
+  && focus.includes("commitDailyCelebratePhase('hidden');\n      dailyCelebrateHideTimer = 0;\n      updateDailyFoot();"),
+  'the ordinary summary must wait for the cancellable signature collapse instead of overlapping it');
+assert(focus.includes('if (generation !== dailyCelebrateGeneration || !dailyCelebrateEl) return;')
+  && focus.includes('focusDailyCelebrateAction(1720);')
+  && focus.includes('}, 2360);') && focus.includes('}, 280);'),
+  'celebration and collapse timers must be cancellable and guarded by the latest state generation');
+const showCelebrate = focus.slice(
+  focus.indexOf('function showDailyCelebrate(animate)'),
+  focus.indexOf('function hideDailyCelebrate(options)'),
+);
+assert(showCelebrate.indexOf("if (dailyCelebratePhase === 'entering' || dailyCelebratePhase === 'visible') return;")
+    < showCelebrate.indexOf('const generation = ++dailyCelebrateGeneration;'),
+  'a confirming server render must leave an in-flight celebration generation and its timers intact');
+const staticCelebrate = showCelebrate.slice(
+  showCelebrate.indexOf('if (!animate || prefersReduced)'),
+  showCelebrate.indexOf("dailyCelebrateEl.classList.remove('is-entering');", showCelebrate.indexOf('if (!animate || prefersReduced)') + 1),
+);
+assert(!staticCelebrate.includes('focusDailyCelebrateAction(')
+  && !focus.slice(focus.indexOf('activate() {'), focus.indexOf('loadDaily({ reveal: !hadDaily')).includes('focusDailyCelebrateAction('),
+  'a restored completion screen must not steal focus when the page is first opened or revisited');
+assert(!focus.includes('dailyCelebrateEl.hidden ='),
+  'celebration visibility must use reversible layout state instead of display-none hard cuts');
+
+[
+  '.focus-daily.focus-daily-view {',
+  'backdrop-filter: none;',
+  '.focus-daily-view .focus-daily-row {',
+  '.focus-daily-view .focus-daily-stat {',
+  '.focus-daily-view .focus-daily-group-head {',
+  '.focus-daily-skeleton span {',
+  'flex: 0 0 auto;',
+  '.focus-embedded.focus-view-transition',
+  '.focus-embedded > .focus-timer-view,',
+  '.focus-embedded > .focus-timer-view {',
+  'left: clamp(10px, 0.75vw, 16px);',
+  'top: clamp(8px, 1vh, 12px);',
+  'grid-template-rows: minmax(0, 1fr);',
+  'grid-area: 1 / 1;',
+  'height: 100%;',
+  'overflow-y: auto;',
+  'scrollbar-gutter: auto;',
+  'box-sizing: border-box;',
+  'animation-delay: calc(150ms + var(--daily-row-index, 0) * 72ms);',
+  '@keyframes focus-daily-heading-spring-in',
+  '@keyframes focus-daily-card-spring-in',
+  '@keyframes focus-daily-support-spring-in',
+  '.focus-daily-row.is-complete-pop::after',
+  '.focus-daily-composer[hidden]',
+  '.focus-daily-create[aria-expanded="true"]',
+  '.focus-daily-celebrate-inner {',
+  '.focus-daily-star-gather {',
+  '.focus-daily-star-dot {',
+  '.focus-daily-star-main {',
+  '.focus-daily-star-halo {',
+  'position: absolute;',
+  'place-items: center;',
+  '.focus-daily-celebrate.is-visible {',
+  '.focus-daily-review-today {',
+  '.focus-daily-scroll {',
+  'scrollbar-width: none;',
+  '.focus-daily-scroll::-webkit-scrollbar',
+  '.focus-daily-view.is-celebration-open .focus-daily-scroll',
+  '.focus-daily-view.is-celebration-entering .focus-daily-scroll',
+  "animation-delay: calc(var(--daily-exit-order, 0) * 48ms);",
+  '@keyframes focus-daily-celebration-card-out',
+  '@keyframes focus-daily-celebration-support-out',
+  '@keyframes focus-daily-star-gather-dot',
+  '@keyframes focus-daily-star-gather-main',
+  '@keyframes focus-daily-star-gather-halo',
+  '.focus-daily-celebrate.is-leaving',
+  'body.start-page[data-start-theme="dark"] .focus-daily.focus-daily-view',
+  '@media (prefers-reduced-motion: reduce)',
+].forEach((needle) => assert(styles.includes(needle), 'missing focus daily-view style: ' + needle));
+
+const focusRootRules = [...styles.matchAll(/\.focus-embedded\s*\{([\s\S]*?)\n\}/g)];
+const stableFocusRootRule = focusRootRules.find((match) => match[1].includes('grid-template-rows: minmax(0, 1fr);'));
+assert(stableFocusRootRule && stableFocusRootRule[1].includes('grid-template-rows: minmax(0, 1fr);')
+  && stableFocusRootRule[1].includes('overflow: hidden;'),
+  'focus root must use a fixed grid track and must not own view scrolling');
+const focusLayerRule = styles.match(/\.focus-embedded > \.focus-timer-view,\s*\n\.focus-embedded > \.focus-daily-view\s*\{([\s\S]*?)\n\}/);
+assert(focusLayerRule && focusLayerRule[1].includes('height: 100%;')
+  && focusLayerRule[1].includes('min-height: 0;')
+  && !focusLayerRule[1].includes('overflow-y: auto;'),
+  'the daily view layer must be a fixed-height non-scrolling overlay host');
+const dailyScrollRule = styles.match(/\.focus-daily-scroll\s*\{([\s\S]*?)\n\}/);
+assert(dailyScrollRule && dailyScrollRule[1].includes('overflow-y: auto;')
+  && dailyScrollRule[1].includes('scrollbar-width: none;')
+  && dailyScrollRule[1].includes('width: min(800px, 100%);'),
+  'only the centered daily scroll port may scroll, and its native scrollbar must stay hidden');
+
+const viewInKeyframes = styles.match(/@keyframes focus-view-layer-in\s*\{([\s\S]*?)\n\}/);
+assert(viewInKeyframes && !viewInKeyframes[1].includes('transform'),
+  'internal view crossfade must not move or scale text');
+const dailyEntranceKeyframes = styles.match(/@keyframes focus-daily-card-spring-in\s*\{([\s\S]*?)\n\}/);
+assert(dailyEntranceKeyframes && dailyEntranceKeyframes[1].includes('translateY(18px) scale(0.975)')
+  && dailyEntranceKeyframes[1].includes('translateY(-3px) scale(1.012)')
+  && dailyEntranceKeyframes[1].includes('translateY(0) scale(1)'),
+  'daily stagger must keep the restored elastic card entrance and settle at identity');
+assert(!styles.includes('focus-daily-data-in'),
+  'first data reveal must not run a second list-level entrance animation');
+assert(focus.includes("replayDailyViewEntrance(dailyEntranceKey, { waitForData: !hadDaily });")
+  && focus.includes("replayDailyViewEntrance(opts.revealKey || ('load-' + focusActivationSeq), { waitForData: false });"),
+  'first activation and data arrival must share one entrance generation');
+const timerSectionKeyframes = styles.match(/@keyframes focus-section-enter\s*\{([\s\S]*?)\n\}/);
+assert(timerSectionKeyframes && !timerSectionKeyframes[1].includes('transform'),
+  'timer section entrance must preserve the stable layout position');
+const timerRingKeyframes = styles.match(/@keyframes focus-ring-wake\s*\{([\s\S]*?)\n\}/);
+assert(timerRingKeyframes && !timerRingKeyframes[1].includes('transform'),
+  'timer ring entrance must not scale and appear to jump');
+assert(!styles.includes('.focus-daily.is-peeking') && !styles.includes('.focus-daily.is-completing'),
+  'removed daily sidebar completion states must not compete with V2 animations');
+assert(!styles.includes('.focus-daily-stat.is-updating'),
+  'task summary text must not blink during rapid completion toggles');
+assert(!styles.includes('.focus-daily.is-revealing .focus-daily-foot,\n.focus-daily.is-revealing .focus-daily-celebrate'),
+  'an already-complete initial load must keep the signature static instead of replaying a page-entrance flourish');
+assert(!styles.includes('.focus-daily-celebrate-burst')
+  && !styles.includes('.focus-daily-celebrate-peek')
+  && !styles.includes('.focus-daily-star-trail')
+  && !styles.includes('.focus-daily-star-path')
+  && !styles.includes('.focus-daily-star-particles')
+  && !styles.includes('--daily-star-soft'),
+  'legacy completion-card and long star-trail decoration must be fully removed');
+const celebrationRule = styles.match(/\.focus-daily-celebrate\s*\{([\s\S]*?)\n\}/);
+assert(celebrationRule && celebrationRule[1].includes('position: absolute;')
+  && celebrationRule[1].includes('inset: 0;')
+  && celebrationRule[1].includes('visibility: hidden;')
+  && celebrationRule[1].includes('color-mix(in srgb, var(--bg) 96%, var(--surface) 4%)'),
+  'the completion celebration must cover the focus content independently of list height or scroll position');
+assert(styles.includes('.focus-daily-celebrate.is-visible,')
+  && styles.includes('.focus-daily-celebrate.is-entering .focus-daily-star-dot,'),
+  'reduced-motion mode must disable the flexible reveal and gathering animations');
+const dailyViewRule = styles.match(/\.focus-daily\.focus-daily-view\s*\{([\s\S]*?)\n\}/);
+assert(dailyViewRule && dailyViewRule[1].includes('box-sizing: border-box;')
+  && dailyViewRule[1].includes('overflow: hidden;'),
+  'the daily view must clip only its own full-size layers while delegating scrolling to the inner port');
+
+[
+  "'每日任务视图': 'Daily tasks view'",
+  "'新增每日任务或分组': 'Add a daily task or group'",
+  "'请先完成收尾或重置当前专注段，再查看每日任务'",
+  "'今日清单已全部完成': \"Today's list is complete.\"",
+  "'回顾今日': 'Review today'",
+  'source.match(/^今天做完了\\s*(\\d+)\\s*件事',
+  'Finished ${match[1]} ${noun} today',
+].forEach((needle) => assert(i18n.includes(needle), 'missing focus daily-view translation: ' + needle));
+
+console.log('focus dual-view contract: ok');

--- a/tests/test_canvas_activity.py
+++ b/tests/test_canvas_activity.py
@@ -1,0 +1,132 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import app
+
+
+class CanvasActivityTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.data = self.root / "data"
+        self.canvases = self.root / "canvases"
+        self.trash = self.canvases / "回收站"
+        self.data.mkdir(parents=True)
+        self.canvases.mkdir(parents=True)
+        self.originals = {
+            "ROOT": app.ROOT,
+            "DATA": app.DATA,
+            "CANVASES": app.CANVASES,
+            "TRASH": app.TRASH,
+            "RECENT_FILE": app.RECENT_FILE,
+            "RECENT_BACKUP_FILE": app.RECENT_BACKUP_FILE,
+            "CANVAS_ACTIVITY_FILE": app.CANVAS_ACTIVITY_FILE,
+        }
+        app.ROOT = self.root
+        app.DATA = self.data
+        app.CANVASES = self.canvases
+        app.TRASH = self.trash
+        app.RECENT_FILE = self.data / "recent.json"
+        app.RECENT_BACKUP_FILE = self.data / "recent.backup.json"
+        app.CANVAS_ACTIVITY_FILE = self.data / "canvas-activity.json"
+        self.canvas = self.canvases / "ideas.canvas"
+
+    def tearDown(self):
+        for name, value in self.originals.items():
+            setattr(app, name, value)
+        self.temp_dir.cleanup()
+
+    def write_canvas(self):
+        payload = {
+            "version": 2,
+            "createdAt": "2025-02-03T09:00:00",
+            "updatedAt": "2025-04-05T18:30:00",
+            "nodes": [],
+            "edges": [],
+        }
+        self.canvas.write_text(json.dumps(payload), encoding="utf-8")
+        app.register_recent(self.canvas)
+        return payload
+
+    def interval(self, started, ended, session="session-123456"):
+        return app.record_canvas_activity_interval({
+            "path": str(self.canvas),
+            "sessionId": session,
+            "startedAt": started,
+            "endedAt": ended,
+        })
+
+    def test_backfill_marks_dates_without_inventing_duration(self):
+        self.write_canvas()
+        snapshot = app.canvas_activity_snapshot()
+        payload = app._canvas_activity_payload(snapshot, 2025)
+
+        self.assertEqual(payload["days"]["2025-02-03"]["createdCount"], 1)
+        self.assertEqual(payload["days"]["2025-04-05"]["modifiedCount"], 1)
+        self.assertEqual(payload["stats"]["yearSec"], 0)
+        self.assertTrue(payload["days"]["2025-02-03"]["inferred"])
+
+    def test_overlapping_heartbeats_are_merged(self):
+        self.write_canvas()
+        app.canvas_activity_register_path(self.canvas)
+        self.interval("2025-06-01T10:00:00", "2025-06-01T10:01:00")
+        totals = self.interval("2025-06-01T10:00:30", "2025-06-01T10:01:30")
+
+        snapshot = app.canvas_activity_snapshot()
+        payload = app._canvas_activity_payload(snapshot, 2025)
+        self.assertEqual(payload["days"]["2025-06-01"]["durationSec"], 90)
+        self.assertEqual(totals["totalSec"], 90)
+
+    def test_interval_is_split_at_local_midnight(self):
+        self.write_canvas()
+        app.canvas_activity_register_path(self.canvas)
+        self.interval("2025-06-01T23:59:50", "2025-06-02T00:00:10")
+
+        snapshot = app.canvas_activity_snapshot()
+        payload = app._canvas_activity_payload(snapshot, 2025)
+        self.assertEqual(payload["days"]["2025-06-01"]["durationSec"], 10)
+        self.assertEqual(payload["days"]["2025-06-02"]["durationSec"], 10)
+
+    def test_managed_move_preserves_canvas_identity(self):
+        self.write_canvas()
+        before = app.canvas_activity_register_path(self.canvas)
+        renamed = self.canvases / "renamed.canvas"
+        self.canvas.rename(renamed)
+        app.move_canvas_activity_path(self.canvas, renamed)
+        after = app.canvas_activity_register_path(renamed)
+
+        self.assertEqual(before["canvasId"], after["canvasId"])
+        snapshot = app.canvas_activity_snapshot()
+        self.assertEqual(snapshot["canvases"][before["canvasId"]]["path"], str(renamed.resolve()))
+
+        # 原路径若日后被另一个文件复用，不能错误继承已重命名画布的历史。
+        self.canvas.write_text(json.dumps({"version": 2, "nodes": [], "edges": []}), encoding="utf-8")
+        replacement = app.canvas_activity_register_path(self.canvas)
+        self.assertNotEqual(before["canvasId"], replacement["canvasId"])
+
+    def test_corrupt_ledger_and_invalid_interval_degrade_safely(self):
+        self.write_canvas()
+        app.CANVAS_ACTIVITY_FILE.write_text("{not-json", encoding="utf-8")
+        registered = app.canvas_activity_register_path(self.canvas)
+        self.assertTrue(registered["canvasId"])
+        json.loads(app.CANVAS_ACTIVITY_FILE.read_text(encoding="utf-8"))
+
+        with self.assertRaises(ValueError):
+            self.interval("2025-06-01T10:00:00", "2025-06-01T10:11:00")
+
+    def test_unauthorized_path_is_rejected(self):
+        outside = self.root / "outside.canvas"
+        outside.write_text(json.dumps({"version": 2, "nodes": []}), encoding="utf-8")
+        with self.assertRaises(PermissionError):
+            app.record_canvas_activity_interval({
+                "path": str(outside),
+                "sessionId": "session-123456",
+                "startedAt": "2025-06-01T10:00:00",
+                "endedAt": "2025-06-01T10:00:30",
+            })
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更内容

- 新增画布活动账本，记录稳定画布身份、创建/修改事件和前台使用时段，并把画布活跃数据接入年度足迹与画布星图。
- 为编辑器和学习页内嵌编辑器加入前台计时、失焦暂停、心跳提交与安全结算。
- 将《专注》页扩展为“专注钟 / 每日任务”双视图，记住用户视图偏好并处理会话锁定及外部强制计时入口。
- 每日任务改为卡片化独立视图，完善缓存刷新、分组、拖拽、快速勾选、详情、新增与响应竞态。
- 重做每日任务全部完成庆祝：内容区覆盖式“微光聚星”、反向错峰缓退、无痕滚动和按日期记忆的“回顾今日”。
- 更新中英文界面、深色/窄屏/低动态样式、维护文档及相关契约测试。

## 原因与影响

原有起步页缺少可靠的画布前台使用统计；专注页的每日任务侧栏也存在首次进入闪烁、布局跳动、滚动条挤压和完成反馈被长列表裁剪等问题。本次改动为画布活动建立独立持久化协议，并把每日任务升级为稳定的专注页内部视图，同时保持现有后端每日任务结构和用户数据兼容。

## 验证

- 修改过的前端脚本均通过 `node --check`
- `node tests/canvas-activity-contract.js`
- `node tests/daily-goal-contract.js`
- `node tests/focus-view-contract.js`
- `python -m unittest discover -s tests -p 'test_*.py'`（90 tests）
- `python -m py_compile app.py`
- `git diff --check`
- 浏览器验证首次进入焦点、长清单无痕滚动、近全屏庆祝及反向错峰退场
