### PR TITLE
Fix maximized desktop window dragging

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,6 +54,10 @@ jobs:
         shell: pwsh
         run: node tests/node-resize-contract.js
 
+      - name: Run desktop window contract tests
+        shell: pwsh
+        run: node tests/desktop-window-contract.js
+
       - name: Run ruler regression tests
         shell: pwsh
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 | --- | --- |
 | `app.py` | 本地 HTTP 服务、路由、持久化、导入导出、AI 代理、独立复习卡片数据库、学习/日历/速记/专注数据。 |
 | `ai_plan.py` | AI 助手 V2 的纯标准库计划层；集中维护紧凑提示词、JSON 提取、动作协议、安全校验和结构修复提示，不写用户数据。 |
-| `desktop.py` | pywebview 桌面壳、WebView2 检测、无边框窗口、窗口状态、未保存关闭确认和动态背景生命周期协调。 |
+| `desktop.py` | pywebview 桌面壳、WebView2 检测、无边框窗口、窗口状态、未保存关闭确认和动态背景生命周期协调；最大化/还原状态会同步到前端标题栏，最大化时由前端拖拽标记与 Win32 位移拦截共同禁止窗口拖移。 |
 | `desktop_instance.py` | Windows 桌面主程序单实例协调；按数据根持有命名互斥锁，通过带认证的本地命名管道转交窗口激活或 `.canvas` 打开请求，并管理 `%TEMP%` 中的短期状态文件。 |
 | `windows_wallpaper.py` | Windows 倒数日动态桌面背景宿主；由主进程管理托盘与生命周期，并从同一个 `Relatum.exe` 启动隔离的只读 WebView2 子进程，严格挂载到 Explorer 的专用全屏 `WorkerW`，同时负责主屏尺寸跟踪、单背景互斥、进程间通信和安全清理。 |
 | `build-desktop.ps1` | PyInstaller onedir 便携版打包，输出 `Relatum-release/Relatum.exe`。脚本保持 ASCII。 |

--- a/assets/desktop-shell.js
+++ b/assets/desktop-shell.js
@@ -116,7 +116,14 @@
   function setMaximized(maximized) {
     document.documentElement.classList.toggle('desktop-maximized', maximized);
     document.body.classList.toggle('desktop-maximized', maximized);
+    // pywebview 的拖拽区会直接调用 SetWindowPos；最大化时必须撤销标记，避免窗口被
+    // 整体移出显示器工作区并在顶部露出空条。还原后再恢复正常的标题栏拖动。
+    bar.classList.toggle('pywebview-drag-region', !maximized);
   }
+
+  window.addEventListener('canvasdesktop:window-state', (event) => {
+    setMaximized(!!(event.detail && event.detail.maximized));
+  });
 
   function setWindowTransitioning(value) {
     windowTransitioning = value;

--- a/desktop.py
+++ b/desktop.py
@@ -39,6 +39,7 @@ WS_MAXIMIZEBOX = 0x00010000
 WS_MINIMIZEBOX = 0x00020000
 WM_NCCALCSIZE = 0x0083
 WM_NCHITTEST = 0x0084
+WM_WINDOWPOSCHANGING = 0x0046
 WM_WINDOWPOSCHANGED = 0x0047
 HTCLIENT = 1
 SW_MINIMIZE = 6
@@ -49,6 +50,11 @@ MONITOR_DEFAULTTONEAREST = 2
 DWMWA_WINDOW_CORNER_PREFERENCE = 33
 DWMWA_BORDER_COLOR = 34
 DWMWA_COLOR_NONE = 0xFFFFFFFE
+SWP_NOSIZE = 0x0001
+SWP_NOMOVE = 0x0002
+SWP_NOZORDER = 0x0004
+SWP_SHOWWINDOW = 0x0040
+PYWEBVIEW_MOVE_FLAGS = SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW
 
 MIN_WIDTH, MIN_HEIGHT = 720, 480
 DEFAULT_WIDTH, DEFAULT_HEIGHT = 1280, 800
@@ -74,6 +80,14 @@ class _MONITORINFO(ctypes.Structure):
 
 class _NCCALCSIZE_PARAMS(ctypes.Structure):
     _fields_ = [("rgrc", wintypes.RECT * 3), ("lppos", ctypes.c_void_p)]
+
+
+class _WINDOWPOS(ctypes.Structure):
+    _fields_ = [
+        ("hwnd", wintypes.HWND), ("hwndInsertAfter", wintypes.HWND),
+        ("x", ctypes.c_int), ("y", ctypes.c_int),
+        ("cx", ctypes.c_int), ("cy", ctypes.c_int), ("flags", wintypes.UINT),
+    ]
 
 
 def _reassert_corners(hwnd: int) -> None:
@@ -159,6 +173,15 @@ def _install_frameless(window) -> None:
                         params = ctypes.cast(lparam, ctypes.POINTER(_NCCALCSIZE_PARAMS))
                         params.contents.rgrc[0] = rect
                 return 0
+            if (msg == WM_WINDOWPOSCHANGING and lparam
+                    and ctypes.windll.user32.IsZoomed(int(h))):
+                # pywebview 的显式拖拽区通过连续 SetWindowPos(..., SWP_NOSIZE) 移动窗口。
+                # Windows 不会自动拒绝这种对最大化窗口的直接定位，结果会把整块最大化客户区
+                # 推离工作区并露出顶部空条。只拦“仅移动”请求，不干扰系统最大化、还原或换屏。
+                position = ctypes.cast(lparam, ctypes.POINTER(_WINDOWPOS))
+                flags = int(position.contents.flags)
+                if flags == PYWEBVIEW_MOVE_FLAGS:
+                    position.contents.flags = flags | SWP_NOMOVE
             if msg == WM_NCHITTEST:
                 # 禁用边缘缩放：把本会落在缩放边框上的命中（HTLEFT..HTBOTTOMRIGHT=10..17）
                 # 改成客户区，原生拖边缩放彻底失效；最大化/移动/动画不受影响。
@@ -215,6 +238,22 @@ def _is_maximized(window) -> bool:
     if sys.platform != "win32" or window is None:
         return False
     return bool(ctypes.windll.user32.IsZoomed(_hwnd(window)))
+
+
+def _notify_window_state(window, maximized: bool) -> None:
+    """Keep the HTML drag region aligned with native maximize/restore events."""
+    if window is None:
+        return
+    try:
+        value = "true" if maximized else "false"
+        window.evaluate_js(
+            "window.dispatchEvent(new CustomEvent('canvasdesktop:window-state',"
+            f"{{detail:{{maximized:{value}}}}}));"
+        )
+    except Exception:
+        # The initial maximize event can precede WebView2/desktop-shell readiness.
+        # desktop-shell.js also queries get_window_state() once the bridge is ready.
+        pass
 
 
 # ── 窗口状态记忆（大小 / 位置 / 最大化） ────────────────────────
@@ -847,10 +886,12 @@ def main() -> int:
     def on_maximized() -> None:
         bridge.maximized = True
         _apply_corners(window, maximized=True)
+        _notify_window_state(window, True)
 
     def on_restored() -> None:
         bridge.maximized = False
         _apply_corners(window, maximized=False)
+        _notify_window_state(window, False)
 
     def confirm_close() -> bool | None:
         # 先记住窗口状态，再处理后台隐藏或未保存提示。

--- a/tests/desktop-window-contract.js
+++ b/tests/desktop-window-contract.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const shell = fs.readFileSync(path.join(root, 'assets', 'desktop-shell.js'), 'utf8');
+const desktop = fs.readFileSync(path.join(root, 'desktop.py'), 'utf8');
+
+assert(shell.includes("bar.classList.toggle('pywebview-drag-region', !maximized)"));
+assert(shell.includes("window.addEventListener('canvasdesktop:window-state'"));
+assert(desktop.includes('WM_WINDOWPOSCHANGING = 0x0046'));
+assert(desktop.includes('PYWEBVIEW_MOVE_FLAGS = SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW'));
+assert(desktop.includes('if flags == PYWEBVIEW_MOVE_FLAGS:'));
+assert(desktop.includes('position.contents.flags = flags | SWP_NOMOVE'));
+assert(desktop.includes("CustomEvent('canvasdesktop:window-state'"));
+
+console.log('desktop window contract passed');


### PR DESCRIPTION
## 修改内容

- 最大化时移除 pywebview 标题栏拖拽标记，还原后恢复
- 将原生最大化/还原事件同步到前端窗口状态
- 在 Win32 `WM_WINDOWPOSCHANGING` 层拦截 pywebview 对最大化窗口的直接位移
- 新增桌面窗口契约测试并接入 CI
- 同步更新 `AGENTS.md` 桌面壳说明

## 原因与影响

pywebview 的显式拖拽区通过 `SetWindowPos` 直接移动窗口。Windows 不会自动拒绝对最大化窗口的这种定位，因此最大化后拖动顶部区域会把客户区移出工作区并露出顶部白条。

修复后，最大化窗口不会再响应标题栏拖移；还原窗口仍可正常拖动。原生拦截只匹配 pywebview 的移动参数，不影响系统最大化、还原或换屏。

## 验证

- `python -m unittest discover -s tests -p "test_*.py"`（90 项通过）
- `python -m py_compile desktop.py`
- `node --check assets/desktop-shell.js`
- `node tests/desktop-window-contract.js`
- 全部手写 JavaScript 语法检查通过
- `git diff --check` 通过
