### PR TITLE
Add manual canvas library sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 - 图片和背景资源按后端上传接口管理。画布附件位于 `.assets/attachments/`。
 - Markdown 附件批注保存在附件旁的 `<asset>.annot.json`。文本区/阅读器手写批注保存在 `.assets/node-annotations.json`。
 - `clean-assets` 会根据画布中仍引用的资源清理孤儿文件；不要手写另一个清理逻辑。
-- 起步页“导入画布”通过服务端原生选择器把一张外部 `.canvas` 复制到 `canvases/`，同名时加 `-2/-3`，并复制实际引用的素材与批注；缺失素材只警告，导入后立即打开项目内副本。“导入文件夹”只接受顶层 `.canvas` 和对应 `.assets`；回收站、未知顶层条目、孤立/未知/缺失素材、损坏批注或链接/重解析点都拒绝整批。批量导入先暂存和复检来源，再一次提交画布、素材、最近索引与活动账本；任一步失败都回滚。外部目录的分组、收藏、排序和回收站不导入。
+- 起步页“导入画布”通过服务端原生选择器把一张外部 `.canvas` 复制到 `canvases/`，同名时加 `-2/-3`，并复制实际引用的素材与批注；缺失素材只警告，导入后立即打开项目内副本。“导入文件夹”只接受顶层 `.canvas` 和对应 `.assets`；回收站、未知顶层条目、孤立/未知/缺失素材、损坏批注或链接/重解析点都拒绝整批。批量导入先暂存和复检来源，再一次提交画布、素材、最近索引与活动账本；任一步失败都回滚。外部目录的分组、收藏、排序和回收站不导入。若用户已经手工把文件复制进当前 `canvases/`，可在起步页“未分组”标题旁手动扫描：只登记合法的顶层 `.canvas`，不复制素材、不伪造打开时间；失效登记必须预览确认后才从 `recent.json` 清理。
 
 ### 浏览器本地偏好
 
@@ -196,7 +196,7 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 ### POST
 
 - 画布文件：`/api/new`、`/api/open`、`/api/pick`、`/api/save`、`/api/remove`、`/api/rename`、`/api/clean-assets`
-- 分组/收藏/排序与可见文件统计：`/api/group-create`、`/api/group-rename`、`/api/group-delete`、`/api/file-set-group`、`/api/favorite-toggle`、`/api/groups-reorder`、`/api/reorder-files`、`/api/file-stats`
+- 分组/收藏/排序与画布库维护：`/api/group-create`、`/api/group-rename`、`/api/group-delete`、`/api/file-set-group`、`/api/favorite-toggle`、`/api/groups-reorder`、`/api/reorder-files`、`/api/file-stats`、`/api/recent-sync`
 - 回收站：`/api/trash`、`/api/trash-list`、`/api/trash-empty`、`/api/restore`
 - 文件系统交互：`/api/reveal`、`/api/open-external`、`/api/open-attachment`
 - 导入导出：`/api/export-markdown`、`/api/export-png`、`/api/import-markdown`、`/api/import-canvas`（起步页拖入内容导入）、`/api/import-canvas-file`（原生单画布复制导入）、`/api/import-canvas-folder`（原生严格文件夹导入）、`/api/canvas-import-assets`（编辑器内部内容导入的受管素材复制）
@@ -378,11 +378,12 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 
 - 首页是书本式工作台，不是营销页。
 - 主要页面顺序包括复习、日历、速记、节奏/活跃、学习、专注、最近、收藏、自定义分组和固定在其后的未分组；另有回收站、帮助、主题/背景设置。
-- `recent.json` v3 的文件项有稳定 `id`、`groupId`、`groupRank`，收藏项另有 `favoriteRank`；最近页只按 `lastOpenedAt` 计算（最多展示 30 项），收藏与分组顺序互不覆盖。旧版 `group` 字段自动迁移，内置页保留 id 不得用作自定义分组 id。
+- `recent.json` v3 的文件项有稳定 `id`、`groupId`、`groupRank`，收藏项另有 `favoriteRank`；最近页只展示具有真实 `lastOpenedAt` 的条目并按该字段计算（最多展示 30 项），收藏与分组顺序互不覆盖。旧版 `group` 字段自动迁移，内置页保留 id 不得用作自定义分组 id。
 - `groupId: ""` 表示“未分组”，不是“最近”。删除自定义分组只把成员移到“未分组”，不删除画布，也不改变收藏状态。
 - `/api/favorite-toggle` 是幂等设置接口，请求必须带布尔 `favorite`；`/api/reorder-files` 必须带 `view`，最近页不可手动排序。
 - 最近文件会展示存在状态、节点数、大小等；失效文件不主动删除，需要用户处理。画布卡片的右键菜单与键盘右方向键共用“移到回收站”操作；若文件已不存在，该操作只清理最近记录和残留视野状态，不生成不可恢复的空回收站条目。
 - `/api/recent` 只返回元数据，不扫描全部画布；存在状态、节点数和大小由 `IntersectionObserver` 对视口附近卡片分批请求 `/api/file-stats`。后端统计按文件身份、大小和时间戳缓存，缓存上限 512 项；文件变化必须自动失效。
+- “未分组”标题旁的循环箭头显式调用 `/api/recent-sync`，扫描范围固定为当前 `canvases/*.canvas`。新发现的合法普通文件按文件名追加到未分组且 `lastOpenedAt` 为空；损坏、超限、链接/重解析点跳过。若存在已登记但缺失的受管顶层画布，首个请求只返回不透明 ID 供确认，确认请求重新核验且只删除那批仍缺失的登记；外部路径、现存条目元数据、画布文件、素材和活动账本均不改。
 - 正常规模保留玻璃卡片与现有翻页/收藏/FLIP 动画；仅列表超过 40 项时取消逐项错峰入场，超过 80 项时关闭卡片 `backdrop-filter` 并启用 `content-visibility`。
 - 分组、收藏、排序都存 `data/recent.json`。
 - 当前页通过 `aria-hidden` / `inert` 与 `start:viewchange` 统一管理；退场动画结束后，隐藏页用 `visibility:hidden` + `content-visibility:hidden` 跳过后代绘制。学习、活跃、速记、日历、复习和专注模块应在离页/pagehide 时暂停自己的计时器、RAF、observer 或音频，不能让隐藏页继续耗帧。
@@ -588,6 +589,13 @@ python -m unittest .\tests\test_canvas_import_library.py
 ```powershell
 python -m unittest .\tests\test_external_canvas_import.py
 node .\tests\start-external-import-contract.js
+```
+
+改动起步页画布库扫描、最近/未分组索引时，还要运行：
+
+```powershell
+python -m unittest .\tests\test_recent_groups.py
+node .\tests\start-recent-sync-contract.js
 ```
 
 改动“工具 → 节点矩阵”、批量节点创建或矩阵布局时，还要运行：

--- a/app.py
+++ b/app.py
@@ -1269,6 +1269,131 @@ def recent_paths() -> set[str]:
     }
 
 
+def _recent_managed_top_level_path(raw_path: object) -> Path | None:
+    """Return a direct managed .canvas path, including one that is now missing."""
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    try:
+        target = Path(raw_path).resolve()
+        managed_root = CANVASES.resolve()
+    except OSError:
+        return None
+    if target.suffix.lower() != ".canvas" or target.parent != managed_root:
+        return None
+    return target
+
+
+def _is_safe_new_managed_canvas(path: Path) -> bool:
+    """Validate a previously unindexed top-level canvas without following links."""
+    try:
+        info = path.lstat()
+        attributes = int(getattr(info, "st_file_attributes", 0) or 0)
+        if path.is_symlink() or bool(attributes & 0x400) or not path.is_file():
+            return False
+        if int(info.st_size) > MAX_JSON_BODY_BYTES:
+            return False
+        with path.open("r", encoding="utf-8-sig") as fh:
+            payload = json.load(fh)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    return isinstance(payload, dict) and isinstance(payload.get("nodes"), list)
+
+
+def _scan_recent_library(data: dict) -> tuple[list[Path], list[dict], int]:
+    """Compare the recent index with direct children of the managed canvas root."""
+    indexed_paths = {
+        os.path.normcase(_norm(item.get("path", "")))
+        for item in data.get("files", [])
+        if isinstance(item, dict) and item.get("path")
+    }
+    additions: list[Path] = []
+    skipped_invalid = 0
+    try:
+        entries = sorted(CANVASES.iterdir(), key=lambda item: item.name.casefold())
+    except OSError as err:
+        raise OSError(f"无法读取画布文件夹：{err}") from err
+    for path in entries:
+        if path.suffix.lower() != ".canvas":
+            continue
+        key = os.path.normcase(_norm(path))
+        if key in indexed_paths:
+            continue
+        if not _is_safe_new_managed_canvas(path):
+            skipped_invalid += 1
+            continue
+        additions.append(path.resolve())
+
+    missing: list[dict] = []
+    for item in data.get("files", []):
+        if not isinstance(item, dict):
+            continue
+        managed = _recent_managed_top_level_path(item.get("path"))
+        if managed is not None and not managed.is_file():
+            missing.append(item)
+    return additions, missing, skipped_invalid
+
+
+@_serialized_data
+def sync_recent_library(confirm_remove_ids: list[str] | None = None) -> dict:
+    """Discover copied canvases and optionally remove confirmed missing entries."""
+    data = load_recent()
+    additions, missing, skipped_invalid = _scan_recent_library(data)
+    missing_by_id = {
+        str(item.get("id") or ""): item
+        for item in missing
+        if str(item.get("id") or "")
+    }
+    if confirm_remove_ids is None and missing_by_id:
+        return {
+            "ok": True,
+            "needsConfirmation": True,
+            "pendingAddedCount": len(additions),
+            "pendingRemovedCount": len(missing_by_id),
+            "skippedInvalidCount": skipped_invalid,
+            "removeIds": list(missing_by_id),
+        }
+
+    confirmed = set(confirm_remove_ids or [])
+    removed_ids = confirmed.intersection(missing_by_id)
+    if removed_ids:
+        data["files"] = [
+            item for item in data.get("files", [])
+            if not isinstance(item, dict) or str(item.get("id") or "") not in removed_ids
+        ]
+
+    inbox_ranks = [
+        _clean_recent_rank(item.get("groupRank"), 0)
+        for item in data.get("files", [])
+        if isinstance(item, dict) and not item.get("groupId")
+    ]
+    next_rank = (max(inbox_ranks) if inbox_ranks else 0) + RECENT_RANK_STEP
+    added_paths: list[str] = []
+    for path in additions:
+        normalized = _norm(path)
+        data["files"].append({
+            "id": _recent_file_id(),
+            "path": normalized,
+            "title": path.stem,
+            "lastOpenedAt": "",
+            "groupId": "",
+            "groupRank": next_rank,
+        })
+        added_paths.append(normalized)
+        next_rank += RECENT_RANK_STEP
+
+    if removed_ids or added_paths:
+        _save_recent_unlocked(data)
+    return {
+        "ok": True,
+        "needsConfirmation": False,
+        "addedCount": len(added_paths),
+        "removedCount": len(removed_ids),
+        "skippedInvalidCount": skipped_invalid,
+        "remainingMissingCount": len(set(missing_by_id) - removed_ids),
+        "addedPaths": added_paths,
+    }
+
+
 def canvas_file_stats(path: Path | str) -> dict:
     """读 .canvas 返回 {sizeBytes, nodeCount}；失败时对应字段给 None。
     按文件身份/时间/大小做有界缓存，避免起步页重复刷新时反复解析未改画布。"""
@@ -6996,6 +7121,7 @@ CANVAS_FILE_POST_ROUTES = {
 }
 CANVAS_AND_DATA_POST_ROUTES = {
     "/api/new",
+    "/api/recent-sync",
     "/api/save",
     "/api/trash",
     "/api/import-canvas",
@@ -7309,6 +7435,8 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     def _dispatch_POST(self, path: str, body: dict):
         if path == "/api/new":
             return self._api_new()
+        if path == "/api/recent-sync":
+            return self._api_recent_sync(body)
         if path == "/api/study-task-create":
             return self._api_study_task_create(body)
         if path == "/api/study-task-update":
@@ -7503,6 +7631,19 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             item["canvasActivitySec"] = totals.get(canvas_id, 0)
         data["recentLimit"] = RECENT_LIMIT
         self._send_json(200, data)
+
+    def _api_recent_sync(self, body: dict):
+        confirm_ids = body.get("confirmRemoveIds") if isinstance(body, dict) else None
+        if confirm_ids is not None and (
+            not isinstance(confirm_ids, list)
+            or not all(isinstance(item, str) for item in confirm_ids)
+        ):
+            return self._send_json(400, {"error": "confirmRemoveIds 必须是字符串数组"})
+        try:
+            result = sync_recent_library(confirm_ids)
+        except OSError as err:
+            return self._send_json(500, {"error": str(err)})
+        self._send_json(200, result)
 
     def _api_file_stats(self, body: dict):
         paths = body.get("paths") if isinstance(body, dict) else None

--- a/assets/i18n.js
+++ b/assets/i18n.js
@@ -27,6 +27,8 @@
     '打开文件': 'Open file', '打开已有文件': 'Open an existing file', '新建画布': 'New canvas',
     '导入画布': 'Import canvas', '导入已有画布': 'Import an existing canvas',
     '导入文件夹': 'Import folder', '导入画布文件夹': 'Import canvas folder',
+    '扫描画布文件夹': 'Scan canvas folder',
+    '扫描 canvases 文件夹，补充新画布并清理失效登记': 'Scan the canvases folder, add new canvases, and clean up missing entries',
     '导入 MD': 'Import MD', '导入 MD 文件夹': 'Import MD folder', '进入学习页': 'Go to Study',
     '右上角可以新建空白画布，也可以把外部': 'Use the upper-right actions to create a blank canvas or copy an external',
     '、整个画布文件夹或 Markdown 文件夹复制导入本项目。': ', a full canvas folder, or a Markdown folder into this project.',

--- a/assets/index.html
+++ b/assets/index.html
@@ -269,7 +269,17 @@
       </nav>
       <div class="book-stage" data-role="book-stage">
         <div class="book-page" data-role="book-page">
-          <h1 class="page-title" data-role="panel-title">最近</h1>
+          <div class="canvas-library-head">
+            <h1 class="page-title" data-role="panel-title">最近</h1>
+            <button type="button" class="page-refresh recent-sync-button" data-action="recent-sync"
+              aria-label="扫描画布文件夹"
+              title="扫描 canvases 文件夹，补充新画布并清理失效登记" hidden>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 3v6h-6"/>
+              </svg>
+            </button>
+          </div>
           <ul class="recent-list" data-role="file-list"></ul>
         </div>
       </div>

--- a/assets/start.js
+++ b/assets/start.js
@@ -22,6 +22,7 @@
   let spineBreatheTimer = 0;
   const fileList = document.querySelector('[data-role="file-list"]');
   const panelTitle = document.querySelector('[data-role="panel-title"]');
+  const recentSyncButton = document.querySelector('[data-action="recent-sync"]');
   const ctxMenu = document.querySelector('[data-role="context-menu"]');
   const toastEl = document.querySelector('[data-role="toast"]');
   const startNotice = document.querySelector('[data-role="start-notice"]');
@@ -1735,7 +1736,8 @@
     buckets.forEach((files) => files.sort(byRank('groupRank')));
     inbox.sort(byRank('groupRank'));
     favorites.sort(byRank('favoriteRank'));
-    const recent = lastFiles.slice().filter((file) => file && file.path)
+    const recent = lastFiles.slice().filter((file) => file && file.path
+      && typeof file.lastOpenedAt === 'string' && file.lastOpenedAt.trim())
       .sort((a, b) => openedAtValue(b) - openedAtValue(a)
         || String(a.id || a.path).localeCompare(String(b.id || b.path)))
       .slice(0, recentLimit);
@@ -1900,6 +1902,7 @@
         && activeGroup !== FAVORITES_PAGE && activeGroup !== INBOX_PAGE);
       panelTitle.textContent = nameOf(activeGroup);
     }
+    if (recentSyncButton) recentSyncButton.hidden = activeGroup !== INBOX_PAGE;
     if (fileStatsObserver) fileStatsObserver.disconnect();
     fileList.innerHTML = '';
     panelFiles = filesOf(activeGroup);
@@ -2538,6 +2541,80 @@
       });
       await refresh();
     } catch (err) { console.warn('[画布] 移除失败', err); }
+  }
+
+  function recentSyncResultMessage(result) {
+    const added = Number(result && result.addedCount) || 0;
+    const removed = Number(result && result.removedCount) || 0;
+    const skipped = Number(result && result.skippedInvalidCount) || 0;
+    const remaining = Number(result && result.remainingMissingCount) || 0;
+    if (!added && !removed && !skipped && !remaining) {
+      return englishUI() ? 'Canvas library is already up to date' : '画布库已是最新';
+    }
+    const parts = englishUI()
+      ? [
+        added ? ('Added ' + added) : '',
+        removed ? ('removed ' + removed + ' missing') : '',
+        skipped ? ('skipped ' + skipped + ' invalid') : '',
+        remaining ? (remaining + ' newly missing left unchanged') : '',
+      ]
+      : [
+        added ? ('新增 ' + added + ' 张') : '',
+        removed ? ('移除 ' + removed + ' 个失效项') : '',
+        skipped ? ('跳过 ' + skipped + ' 个异常文件') : '',
+        remaining ? ('另有 ' + remaining + ' 个新失效项未清理') : '',
+      ];
+    return parts.filter(Boolean).join(' · ');
+  }
+
+  async function requestRecentSync(confirmRemoveIds) {
+    const body = Array.isArray(confirmRemoveIds) ? { confirmRemoveIds } : {};
+    const response = await fetch('/api/recent-sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    let json = {};
+    try { json = await response.json(); } catch (err) {}
+    if (!response.ok) throw new Error(json.error || (englishUI() ? 'Scan failed' : '扫描失败'));
+    return json;
+  }
+
+  if (recentSyncButton) {
+    recentSyncButton.addEventListener('click', async () => {
+      if (recentSyncButton.disabled) return;
+      recentSyncButton.disabled = true;
+      recentSyncButton.classList.add('is-refreshing');
+      recentSyncButton.setAttribute('aria-busy', 'true');
+      try {
+        let result = await requestRecentSync();
+        if (result.needsConfirmation) {
+          const added = Number(result.pendingAddedCount) || 0;
+          const removed = Number(result.pendingRemovedCount) || 0;
+          const skipped = Number(result.skippedInvalidCount) || 0;
+          const message = englishUI()
+            ? ('Found ' + added + ' new canvas(es) and ' + removed + ' missing list item(s).'
+              + (skipped ? (' ' + skipped + ' invalid file(s) will be skipped.') : '')
+              + '\n\nRemove the missing items from the list and continue? No canvas files will be deleted.')
+            : ('发现 ' + added + ' 张新画布和 ' + removed + ' 个失效登记。'
+              + (skipped ? ('另有 ' + skipped + ' 个异常文件会被跳过。') : '')
+              + '\n\n是否从列表移除失效登记并继续？不会删除任何画布文件。');
+          if (!window.confirm(message)) return;
+          result = await requestRecentSync(result.removeIds || []);
+        }
+        (result.addedPaths || []).forEach((path) => {
+          if (path) flashImportPaths.add(path);
+        });
+        await refresh();
+        showToast(recentSyncResultMessage(result));
+      } catch (err) {
+        showToast((englishUI() ? 'Scan failed: ' : '扫描失败：') + err.message);
+      } finally {
+        recentSyncButton.disabled = false;
+        recentSyncButton.classList.remove('is-refreshing');
+        recentSyncButton.removeAttribute('aria-busy');
+      }
+    });
   }
 
   async function trashCanvas(f, li, armNext) {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -13914,13 +13914,43 @@ body.start-page[data-start-theme="dark"] .start-page-note.is-selected {
 }
 
 /* 大页标题（每页 = 分组名）*/
+.canvas-library-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 0 0 30px;
+}
+
 .page-title {
   font-size: 44px;
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1.1;
-  margin: 0 0 30px;
+  margin: 0;
   color: var(--text);
+}
+
+.recent-sync-button {
+  flex: none;
+  width: 36px;
+  height: 36px;
+  justify-content: center;
+  padding: 0;
+  border-radius: 50%;
+}
+
+.recent-sync-button[hidden] { display: none; }
+
+body.start-page[data-start-theme="dark"] .recent-sync-button {
+  border-color: rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.07);
+  color: rgba(244, 241, 232, 0.72);
+}
+
+body.start-page[data-start-theme="dark"] .recent-sync-button:hover {
+  border-color: rgba(255, 255, 255, 0.24);
+  background: rgba(255, 255, 255, 0.12);
+  color: #f4f1e8;
 }
 
 /* 空分组提示 */

--- a/tests/start-recent-sync-contract.js
+++ b/tests/start-recent-sync-contract.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const read = (...parts) => fs.readFileSync(path.join(root, ...parts), 'utf8');
+const html = read('assets', 'index.html');
+const start = read('assets', 'start.js');
+const styles = read('assets', 'styles.css');
+const i18n = read('assets', 'i18n.js');
+const backend = read('app.py');
+
+assert(html.includes('data-action="recent-sync"'), '未分组扫描按钮缺失');
+assert(html.includes('aria-label="扫描画布文件夹"') && html.includes('hidden'),
+  '扫描按钮必须默认隐藏并提供无障碍名称');
+assert(start.includes('recentSyncButton.hidden = activeGroup !== INBOX_PAGE'),
+  '扫描按钮只能在未分组页显示');
+assert(start.includes("fetch('/api/recent-sync'"), '扫描按钮必须调用 recent-sync 接口');
+assert(start.includes('result.needsConfirmation') && start.includes('window.confirm(message)'),
+  '存在失效登记时必须先预览并确认');
+assert(start.includes('requestRecentSync(result.removeIds || [])'),
+  '确认请求只能提交预览返回的不透明条目 ID');
+assert(start.includes("recentSyncButton.classList.add('is-refreshing')")
+  && start.includes("recentSyncButton.classList.remove('is-refreshing')"),
+  '扫描按钮必须提供有限加载反馈');
+assert(start.includes("typeof file.lastOpenedAt === 'string' && file.lastOpenedAt.trim()"),
+  '最近页必须排除从未打开的扫描条目');
+assert(start.includes('新增 ') && start.includes('Canvas library is already up to date'),
+  '扫描结果必须提供中英文反馈');
+assert(styles.includes('.recent-sync-button[hidden] { display: none; }'),
+  '按钮隐藏状态不能被通用 flex 样式覆盖');
+assert(styles.includes('body.start-page[data-start-theme="dark"] .recent-sync-button'),
+  '扫描按钮必须适配深色起步页');
+assert(i18n.includes("'扫描画布文件夹': 'Scan canvas folder'"),
+  '扫描按钮必须提供英文说明');
+[
+  '"/api/recent-sync"',
+  'def sync_recent_library(',
+  'def _api_recent_sync(',
+  '"needsConfirmation": True',
+  '"lastOpenedAt": ""',
+].forEach((needle) => assert(backend.includes(needle), '后端扫描契约缺失：' + needle));
+
+console.log('start recent sync contract passed');

--- a/tests/test_recent_groups.py
+++ b/tests/test_recent_groups.py
@@ -36,6 +36,14 @@ class RecentGroupsTest(unittest.TestCase):
             json.dumps(payload, ensure_ascii=False), encoding="utf-8",
         )
 
+    def write_canvas(self, name, payload=None):
+        path = self.canvases_dir / name
+        path.write_text(
+            json.dumps(payload if payload is not None else {"nodes": []}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        return path
+
     def test_v2_migrates_to_v3_with_stable_ids_and_independent_ranks(self):
         first = str(self.canvases_dir / "第一张.canvas")
         second = str(self.canvases_dir / "第二张.canvas")
@@ -232,6 +240,126 @@ class RecentGroupsTest(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["nodeCount"], 2)
         self.assertTrue(result[0]["exists"])
+
+    def test_library_sync_adds_valid_top_level_canvases_at_inbox_end_and_is_idempotent(self):
+        existing = self.write_canvas("保留.canvas")
+        alpha = self.write_canvas("A.canvas", {"nodes": [{}]})
+        beta = self.write_canvas("B.canvas", {"nodes": [{}, {}]})
+        self.write_recent({
+            "version": 3,
+            "groups": [{"id": "g1", "name": "原分组"}],
+            "files": [{
+                "id": "cf_keep", "path": str(existing), "title": "保留标题",
+                "lastOpenedAt": "2026-08-01T10:00:00", "groupId": "g1",
+                "groupRank": 4096, "favorite": True, "favoriteRank": 1024,
+            }],
+        })
+
+        with mock.patch.object(target, "_save_recent_unlocked", wraps=target._save_recent_unlocked) as save:
+            result = target.sync_recent_library()
+
+        self.assertFalse(result["needsConfirmation"])
+        self.assertEqual(result["addedCount"], 2)
+        self.assertEqual(result["removedCount"], 0)
+        self.assertEqual(result["addedPaths"], [str(alpha.resolve()), str(beta.resolve())])
+        save.assert_called_once()
+        synced = target.load_recent()
+        kept = next(item for item in synced["files"] if item["id"] == "cf_keep")
+        self.assertEqual(kept["title"], "保留标题")
+        self.assertEqual(kept["groupId"], "g1")
+        self.assertTrue(kept["favorite"])
+        additions = [item for item in synced["files"] if item["id"] != "cf_keep"]
+        self.assertEqual([item["title"] for item in additions], ["A", "B"])
+        self.assertTrue(all(item["groupId"] == "" for item in additions))
+        self.assertTrue(all(item["lastOpenedAt"] == "" for item in additions))
+        self.assertLess(additions[0]["groupRank"], additions[1]["groupRank"])
+
+        second = target.sync_recent_library()
+        self.assertEqual(second["addedCount"], 0)
+        self.assertEqual(len(target.load_recent()["files"]), 3)
+
+    def test_library_sync_previews_missing_without_writing_then_removes_only_confirmed_ids(self):
+        first_missing = self.canvases_dir / "旧一.canvas"
+        second_missing = self.canvases_dir / "旧二.canvas"
+        external_missing = self.root / "外部.canvas"
+        self.write_recent({
+            "version": 3,
+            "groups": [{"id": "g1", "name": "保留分组"}],
+            "files": [
+                {
+                    "id": "cf_first", "path": str(first_missing), "title": "旧一",
+                    "lastOpenedAt": "2026-08-01T10:00:00", "groupId": "g1",
+                    "groupRank": 0, "favorite": True, "favoriteRank": 0,
+                },
+                {
+                    "id": "cf_external", "path": str(external_missing), "title": "外部",
+                    "lastOpenedAt": "2026-08-01T11:00:00", "groupId": "",
+                    "groupRank": 0,
+                },
+            ],
+        })
+
+        before = self.recent_file.read_bytes()
+        preview = target.sync_recent_library()
+        self.assertTrue(preview["needsConfirmation"])
+        self.assertEqual(preview["pendingRemovedCount"], 1)
+        self.assertEqual(preview["removeIds"], ["cf_first"])
+        self.assertEqual(self.recent_file.read_bytes(), before)
+
+        changed = target.load_recent()
+        changed["files"].append({
+            "id": "cf_second", "path": str(second_missing), "title": "旧二",
+            "lastOpenedAt": "", "groupId": "", "groupRank": 1024,
+        })
+        target.save_recent(changed)
+        result = target.sync_recent_library(preview["removeIds"])
+
+        self.assertEqual(result["removedCount"], 1)
+        self.assertEqual(result["remainingMissingCount"], 1)
+        ids = {item["id"] for item in target.load_recent()["files"]}
+        self.assertNotIn("cf_first", ids)
+        self.assertIn("cf_second", ids)
+        self.assertIn("cf_external", ids)
+
+    def test_library_sync_skips_invalid_oversized_nested_and_trash_canvases(self):
+        valid = self.write_canvas("有效.canvas")
+        tracked_invalid = self.canvases_dir / "已登记但损坏.canvas"
+        tracked_invalid.write_text("{temporarily broken", encoding="utf-8")
+        invalid_json = self.canvases_dir / "损坏.canvas"
+        invalid_json.write_text("{not json", encoding="utf-8")
+        self.write_canvas("结构错误.canvas", {"edges": []})
+        oversized = self.canvases_dir / "过大.canvas"
+        oversized.write_text('{"nodes":[],"padding":"' + ('x' * 80) + '"}', encoding="utf-8")
+        nested = self.canvases_dir / "子目录"
+        nested.mkdir()
+        (nested / "嵌套.canvas").write_text('{"nodes":[]}', encoding="utf-8")
+        trash = self.canvases_dir / "回收站"
+        trash.mkdir()
+        (trash / "已删除.canvas").write_text('{"nodes":[]}', encoding="utf-8")
+        self.write_recent({
+            "version": 3,
+            "groups": [],
+            "files": [{
+                "id": "cf_tracked_invalid", "path": str(tracked_invalid),
+                "title": "已登记但损坏", "lastOpenedAt": "2026-08-01T10:00:00",
+                "groupId": "", "groupRank": 0,
+            }],
+        })
+
+        with mock.patch.object(target, "MAX_JSON_BODY_BYTES", 64):
+            result = target.sync_recent_library()
+
+        self.assertEqual(result["addedCount"], 1)
+        self.assertEqual(result["addedPaths"], [str(valid.resolve())])
+        self.assertEqual(result["skippedInvalidCount"], 3)
+        synced = target.load_recent()["files"]
+        self.assertIn("cf_tracked_invalid", {item["id"] for item in synced})
+        self.assertEqual([item["title"] for item in synced], ["已登记但损坏", "有效"])
+
+    def test_new_managed_canvas_validation_rejects_links(self):
+        linked = self.write_canvas("链接.canvas")
+        with mock.patch.object(Path, "is_symlink", return_value=True):
+            self.assertFalse(target._is_safe_new_managed_canvas(linked))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- add a manual scan action beside the Ungrouped canvas-library heading
- discover valid top-level `.canvas` files copied into `canvases/` and append them without fabricating open timestamps
- preview and explicitly confirm cleanup of missing managed entries without deleting canvas files
- keep Recent limited to canvases with a real `lastOpenedAt`
- add backend and frontend contract coverage and update the maintenance guide

## Why

The recent index previously had no safe way to reconcile canvases copied directly into the managed folder or stale entries whose files had disappeared. Users could end up with valid canvases that were invisible in the library or invalid entries that required manual data edits.

## Impact

Users can now rescan the managed canvas folder from the Ungrouped page. New valid canvases are registered safely, invalid files are skipped, and stale registrations are removed only after confirmation. Existing group, favorite, canvas, asset, and activity data remain unchanged.

## Validation

- `python -m unittest discover -s tests -p 'test_*.py'` — 119 passed
- `python -m unittest .\\tests\\test_recent_groups.py` — 12 passed
- `node .\\tests\\start-recent-sync-contract.js` — passed
- `python -m py_compile app.py`
- `node --check assets\\start.js`
- `node --check assets\\i18n.js`
- Full JS contract sweep: all but two existing unrelated contracts passed; `ai-panel-v2-contract.js` and `tools-neutral-ui-contract.js` still fail on AI/tool surface styling assertions outside this diff.
