### PR TITLE
Rename repository references to Relatum

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@
 
 <p align="center">
   <a href="README_EN.md">English</a> ·
-  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest/download/Relatum-release.zip"><strong>下载 Windows 版</strong></a> ·
-  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest">查看最新版本</a> ·
+  <a href="https://github.com/yamibk/Relatum/releases/latest/download/Relatum-release.zip"><strong>下载 Windows 版</strong></a> ·
+  <a href="https://github.com/yamibk/Relatum/releases/latest">查看最新版本</a> ·
   <a href="CONTRIBUTING.md">参与贡献</a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/yamibk/Relatum-Opensource?style=flat-square"></a>
+  <a href="https://github.com/yamibk/Relatum/releases/latest"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/yamibk/Relatum?style=flat-square"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-111111?style=flat-square"></a>
   <img alt="Windows 10 and 11" src="https://img.shields.io/badge/platform-Windows%2010%20%7C%2011-2563eb?style=flat-square">
   <img alt="Local first" src="https://img.shields.io/badge/data-local--first-2f855a?style=flat-square">
 </p>
 
 <p align="center">
-  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest">
+  <a href="https://github.com/yamibk/Relatum/releases/latest">
     <img src="https://github.com/user-attachments/assets/fed0dc96-c635-4e79-99c4-fef8f8eb8195" alt="Relatum 自由画布、节点连接与思维导图界面">
   </a>
 </p>
@@ -109,7 +109,7 @@ Relatum 是一款开源、本地优先的自由知识画布和学习工作台。
 
 ### 下载 Windows 桌面版
 
-1. [下载最新版 `Relatum-release.zip`](https://github.com/yamibk/Relatum-Opensource/releases/latest/download/Relatum-release.zip)。
+1. [下载最新版 `Relatum-release.zip`](https://github.com/yamibk/Relatum/releases/latest/download/Relatum-release.zip)。
 2. 将 ZIP 完整解压到一个可写目录。
 3. 双击 `Relatum.exe`。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -12,20 +12,20 @@
 
 <p align="center">
   <a href="README.md">简体中文</a> ·
-  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest/download/Relatum-release.zip"><strong>Download for Windows</strong></a> ·
-  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest">Latest release</a> ·
+  <a href="https://github.com/yamibk/Relatum/releases/latest/download/Relatum-release.zip"><strong>Download for Windows</strong></a> ·
+  <a href="https://github.com/yamibk/Relatum/releases/latest">Latest release</a> ·
   <a href="CONTRIBUTING.md">Contribute</a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/yamibk/Relatum-Opensource?style=flat-square"></a>
+  <a href="https://github.com/yamibk/Relatum/releases/latest"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/yamibk/Relatum?style=flat-square"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-111111?style=flat-square"></a>
   <img alt="Windows 10 and 11" src="https://img.shields.io/badge/platform-Windows%2010%20%7C%2011-2563eb?style=flat-square">
   <img alt="Local first" src="https://img.shields.io/badge/data-local--first-2f855a?style=flat-square">
 </p>
 
 <p align="center">
-  <a href="https://github.com/yamibk/Relatum-Opensource/releases/latest">
+  <a href="https://github.com/yamibk/Relatum/releases/latest">
     <img src="https://github.com/user-attachments/assets/fed0dc96-c635-4e79-99c4-fef8f8eb8195" alt="Relatum freeform canvas with connected notes and mind maps">
   </a>
 </p>
@@ -109,7 +109,7 @@ No account is required. Canvases, preferences, and optional AI credentials stay 
 
 ### Download the Windows app
 
-1. [Download the latest `Relatum-release.zip`](https://github.com/yamibk/Relatum-Opensource/releases/latest/download/Relatum-release.zip).
+1. [Download the latest `Relatum-release.zip`](https://github.com/yamibk/Relatum/releases/latest/download/Relatum-release.zip).
 2. Fully extract the ZIP into a writable folder.
 3. Run `Relatum.exe`.
 

--- a/Relatum-维护工具/00-README-开源项目维护.md
+++ b/Relatum-维护工具/00-README-开源项目维护.md
@@ -11,7 +11,7 @@
 以后只使用真正的 Relatum Git 仓库开发。它应包含 `.git`、`app.py`、`assets/` 和 `build-desktop.ps1`。
 
 ```text
-Relatum-Opensource\
+Relatum\
 ├─ .git\
 ├─ app.py
 ├─ assets\
@@ -23,7 +23,7 @@ Relatum-Opensource\
 它连接的云端仓库是：
 
 ```text
-https://github.com/yamibk/Relatum-Opensource
+https://github.com/yamibk/Relatum
 ```
 
 不要再把历史工程、GitHub 下载的 ZIP、`Relatum-release` 发布目录当成日常源码继续修改。

--- a/Relatum-维护工具/01-Git零基础词典.md
+++ b/Relatum-维护工具/01-Git零基础词典.md
@@ -4,8 +4,8 @@
 
 严格来说，现在确实有两个 Git 仓库：
 
-- 本地仓库：电脑里的 `Relatum-Opensource\Relatum-Opensource` 文件夹，以及其中隐藏的 `.git` 历史。
-- 远端仓库：GitHub 上的 `yamibk/Relatum-Opensource`。
+- 本地仓库：电脑里的 `Relatum` 文件夹，以及其中隐藏的 `.git` 历史。
+- 远端仓库：GitHub 上的 `yamibk/Relatum`。
 
 但它们不是两个需要人工分别维护的项目，而是同一个项目的本地副本和云端副本。两者通过名为 `origin` 的连接关联。
 

--- a/Relatum-维护工具/构建Relatum-release.bat
+++ b/Relatum-维护工具/构建Relatum-release.bat
@@ -35,6 +35,7 @@ if defined RELATUM_REPO (
     )
 )
 if not defined REPO call :try_repo "%~dp0.."
+if not defined REPO call :try_repo "%~dp0..\Relatum"
 if not defined REPO call :try_repo "%~dp0..\Relatum-Opensource"
 if not defined REPO for /d %%D in ("%~dp0..\*") do if not defined REPO call :try_repo "%%~fD"
 


### PR DESCRIPTION
## What changed

- update Chinese and English README release links and badge URLs to `yamibk/Relatum`
- update maintenance documentation to use the concise repository name
- add `Relatum` as the preferred local folder lookup while retaining legacy-folder compatibility

## Why

The public repository has been renamed from `Relatum-Opensource` to `Relatum`. These updates remove stale public links and keep local maintenance tooling aligned with the new name.

## Validation

- `git diff --check`
- `scripts/check-public.ps1`
- verified release `v14.4` and `Relatum-release.zip` under `yamibk/Relatum`
