### PR TITLE
补充速记控制台收起动画

### DIFF
--- a/assets/start.js
+++ b/assets/start.js
@@ -443,6 +443,7 @@
     let open = false;
     let nearTrigger = false;
     let resetTimer = 0;
+    let consoleCloseTimer = 0;
     let helpCloseTimer = 0;
     let helpOpen = false;
     const allColors = notesConsolePanel.querySelector('[data-action="notes-colors-all"]');
@@ -452,14 +453,35 @@
     }
 
     function setOpen(next, restoreFocus) {
+      if (!next && !open && notesConsolePanel.classList.contains('is-closing')) {
+        if (restoreFocus) notesConsoleTrigger.focus({ preventScroll: true });
+        return;
+      }
+      const shouldAnimateClose = !next && !notesConsolePanel.hidden
+        && !notesConsolePanel.classList.contains('is-closing') && !prefersReduced;
+      clearTimeout(consoleCloseTimer);
       open = !!next;
       if (!open) setHelpOpen(false, false);
       notesConsole.classList.toggle('is-open', open);
       notesConsoleTrigger.setAttribute('aria-expanded', open ? 'true' : 'false');
-      notesConsolePanel.hidden = !open;
       notesConsolePanel.inert = !open;
-      if (open) notesConsolePanel.removeAttribute('inert');
-      else notesConsolePanel.setAttribute('inert', '');
+      if (open) {
+        notesConsolePanel.classList.remove('is-closing');
+        notesConsolePanel.hidden = false;
+        notesConsolePanel.removeAttribute('inert');
+      } else {
+        notesConsolePanel.setAttribute('inert', '');
+        if (shouldAnimateClose) {
+          notesConsolePanel.classList.add('is-closing');
+          consoleCloseTimer = window.setTimeout(() => {
+            if (open) return;
+            notesConsolePanel.hidden = true;
+            notesConsolePanel.classList.remove('is-closing');
+          }, 160);
+        } else if (!notesConsolePanel.classList.contains('is-closing')) {
+          notesConsolePanel.hidden = true;
+        }
+      }
       setRevealed(open || nearTrigger || notesConsole.matches(':focus-within'));
       if (!open && restoreFocus) notesConsoleTrigger.focus({ preventScroll: true });
     }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -14415,6 +14415,10 @@ body.start-page[data-start-theme="dark"] .focus-round-pip.is-done { background: 
 
 .notes-console-panel::-webkit-scrollbar { display: none; }
 .notes-console-panel[hidden] { display: none; }
+.notes-console-panel.is-closing {
+  pointer-events: none;
+  animation: notes-console-out 160ms cubic-bezier(.4, 0, 1, 1) both;
+}
 
 @keyframes notes-console-in {
   from { opacity: 0; transform: translate3d(10px, -50%, 0) scale(0.985); }
@@ -14994,6 +14998,7 @@ body.start-page[data-start-theme="dark"] .notes-surface:not(.notes-searching) .s
   .notes-console-section-head > button,
   .notes-console-view-actions button { transition: none; }
   .notes-console-panel,
+  .notes-console-panel.is-closing,
   .notes-console-shortcuts,
   .notes-console-shortcuts.is-closing { animation: none; }
   .start-speed-pop,


### PR DESCRIPTION
## 改动

- 为速记控制台主面板补充收起动画：淡出、缩小并向右缘回收。
- 处理中途重新打开和点外部关闭，避免关闭动画被打断。
- 在低动态模式下保留即时关闭行为。

## 验证

- `node --check assets/start.js`
- `node tests/sticky-palette-contract.js`
- `git diff --check`
