### PR TITLE
Optimize editor opening performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,8 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 | `trash.html` | 回收站管理页。 |
 | `assets/start.js` | 起步页状态、最近/分组/收藏、页面切换、主题/背景/翻页速度。 |
 | `assets/editor.js` | 编辑器页面编排：加载/保存、模式切换、模板、导出、背景、AI/图谱入口和参考画布父页协调。 |
+| `assets/editor-lazy.js` | 编辑器非首屏运行时协调：AI/图谱首次交互可立即抢先加载，未交互时在揭幕后空闲补载；新手引导/说明框揭幕后补载，并在揭幕后空闲触发 KoseFont 补齐；不得让这些资源重新进入首屏阻塞链。 |
+| `assets/font-loader.js` | 主编辑器与双屏参考查看器共用的大字体按需注册层；只有真实手写文字/文字框画布或编辑器揭幕后空闲补齐时才注册并加载 KoseFont。 |
 | `assets/editor-onboarding.js` | 编辑器首次使用引导：十一页 CSS 演示浮窗、翻页/重播、中英文案和真实画布四步练习。 |
 | `assets/i18n.js` | 起始页与编辑器共用的界面语言层；保存语言偏好、翻译静态/动态 UI，并保护用户内容区。 |
 | `assets/tooltip.js` | 全局自定义说明框层；接管静态与动态 `title`，同步中英文文案，并处理悬停/键盘焦点与视口避让。 |
@@ -148,6 +150,10 @@ Relatum 是一个离线优先的本地学习与知识组织工具：
 | 桌面窗口状态 | `data/window-state.json` |
 
 全新用户尚无 `data/background.json` 且当前画布也没有旧版背景字段时，编辑器出厂默认使用“月灰”纯色、横线纸底纹、全屏沉浸、浅色背景语义，并关闭标题栏可读性保护；首次加载后会把这组全局背景偏好写入 `data/background.json`。辅助底纹是独立的全局可选偏好；新用户缺省为横线纸，迁移只有旧版背景字段的画布时仍保持无底纹；可选无底纹、横线、点格、方格或主次方格，与原背景共存而不写入 `.canvas`。
+
+起步页拿到全局背景偏好后会立即用低请求优先级预热图片背景并同步深浅语义。`/api/background-image` 允许浏览器私有保存响应字节，但每次通过基于文件修改时间与大小的 ETag 向本地服务复检；画布附件仍保持 `no-store`。编辑器揭幕只等待最终背景底色、画布与标题，不等待位图下载；图片完成后在背景层淡入。纯色背景不产生图片请求。
+
+`editor.html` 在 `<head>` 里声明首屏核心 `defer` 脚本，使下载与大型编辑器 DOM 解析重叠；同一阶段通过 `window.__relatumOpeningRequests` 提前并行启动 `/api/load` 与 `/api/background-preference`，`editor.js` 必须复用这两个 Promise，不能重复请求。AI、图谱、新手引导、说明框与 KoseFont 不属于普通画布揭幕的阻塞链；AI 与图谱在揭幕后空闲补载，首次交互可抢先复用同一个加载 Promise。
 
 ### `.canvas` 和 `.assets`
 
@@ -679,6 +685,12 @@ node .\tests\node-resize-contract.js
 ```powershell
 node .\tests\canvas-performance-contract.js
 python .\tests\generate-performance-fixtures.py <隔离的 Relatum 运行目录>
+```
+
+改动编辑器首屏脚本、延迟运行时、手写字体或背景揭幕/缓存时，还要运行：
+
+```powershell
+node .\tests\editor-opening-performance-contract.js
 ```
 
 性能夹具只能写入一次性隔离运行目录，禁止指向仓库真实 `canvases/` 或 `data/`。`?perf=1` 才会暴露 `window.__relatumPerfSnapshot()` 与隐藏的 `#relatum-perf-snapshot`；正常页面不得创建调试全局、采样循环或输出节点。

--- a/app.py
+++ b/app.py
@@ -8082,21 +8082,41 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             raise RequestBodyError(400, "请求 JSON 顶层必须是对象")
         return payload
 
-    def _send_local_file(self, target: Path, media_type: str, error_prefix: str) -> None:
+    def _send_local_file(
+        self,
+        target: Path,
+        media_type: str,
+        error_prefix: str,
+        *,
+        cache_control: str = "no-store",
+    ) -> None:
         """Stream a local asset with single-range support and bounded memory."""
         fh = None
         try:
             fh = target.open("rb")
-            size = os.fstat(fh.fileno()).st_size
+            stat = os.fstat(fh.fileno())
+            size = stat.st_size
         except OSError as err:
             if fh is not None:
                 fh.close()
             return self._send_json(500, {"error": f"{error_prefix}：{err}"})
 
+        etag = f'"{stat.st_mtime_ns:x}-{size:x}"'
+        range_header = str(self.headers.get("Range") or "").strip()
+        if cache_control != "no-store" and not range_header:
+            if str(self.headers.get("If-None-Match") or "").strip() == etag:
+                fh.close()
+                self.send_response(304)
+                self.send_header("ETag", etag)
+                self.send_header("Cache-Control", cache_control)
+                self.send_header("Accept-Ranges", "bytes")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+
         start = 0
         end = max(0, size - 1)
         partial = False
-        range_header = str(self.headers.get("Range") or "").strip()
         if range_header:
             match = re.fullmatch(r"bytes=(\d*)-(\d*)", range_header)
             if not match or (not match.group(1) and not match.group(2)):
@@ -8134,9 +8154,11 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             self.send_header("Content-Type", media_type)
             self.send_header("Accept-Ranges", "bytes")
             self.send_header("Content-Length", str(length))
+            if cache_control != "no-store":
+                self.send_header("ETag", etag)
             if partial:
                 self.send_header("Content-Range", f"bytes {start}-{end}/{size}")
-            self.send_header("Cache-Control", "no-store")
+            self.send_header("Cache-Control", cache_control)
             self.end_headers()
             if length:
                 fh.seek(start)
@@ -10040,7 +10062,14 @@ class Handler(http.server.SimpleHTTPRequestHandler):
                 return self._send_json(413, {"error": "背景图片太大（上限 40MB）"})
         except OSError as err:
             return self._send_json(500, {"error": f"读取背景图片失败：{err}"})
-        return self._send_local_file(target, media_type, "读取背景图片失败")
+        # 背景页会在起步页预热、编辑器复用。允许浏览器保存字节，但每次用 ETag
+        # 向本地服务确认文件未变化，兼顾外部原图可能被用户替换的情况。
+        return self._send_local_file(
+            target,
+            media_type,
+            "读取背景图片失败",
+            cache_control="private, no-cache",
+        )
 
     def _api_canvas_asset(self, raw_path: str, asset_path: str):
         """向页面提供某张画布伴生目录内的装饰图片。"""

--- a/assets/canvas.js
+++ b/assets/canvas.js
@@ -882,6 +882,12 @@
     // 当前 .canvas 文件所在目录（去掉最后一段文件名）
     const baseDir = filePath.replace(/[\\/][^\\/]*$/, '');
     const data = opts.data;
+    function ensureKoseFont() {
+      const loader = global.RelatumFontLoader;
+      return loader && typeof loader.ensureKose === 'function'
+        ? loader.ensureKose()
+        : Promise.resolve();
+    }
     const Ruler = global.RelatumRuler || null;
     const Timer = global.RelatumCanvasTimer || null;
     const Taskbooks = global.RelatumCanvasTaskbooks || null;
@@ -1527,6 +1533,7 @@
 
     function setDrawTool(tool) {
       const nextTool = tool || 'select';
+      if (nextTool === 'text') ensureKoseFont();
       if (drawTool === 'edge-anchor' && nextTool !== 'edge-anchor') {
         let clearedAnchorSelection = false;
         selectedNodeIds.forEach((id) => {
@@ -6108,6 +6115,7 @@
         el.appendChild(content);
       }
       if (isTextBoxNode(node)) {
+        ensureKoseFont();
         renderTextBox(content, node);
       } else if (isImageNode(node)) {
         renderCanvasImage(content, el, node);
@@ -6123,6 +6131,7 @@
       }
       let title = el.querySelector('.decor-box-title');
       if (isGroupBoxNode(node)) {
+        ensureKoseFont();
         if (!title) {
           title = document.createElement('div');
           title.className = 'decor-box-title';
@@ -8832,6 +8841,7 @@
     window.setTimeout(retryTaskbookFocusLogs, 0);
 
     function createNodeEl(node) {
+      if (node && node.handText) ensureKoseFont();
       const el = document.createElement('div');
       el.className = 'node';
       el.dataset.id = node.id;
@@ -16757,6 +16767,7 @@
     }
 
     function createHandTextAt(e) {
+      ensureKoseFont();
       const p = clientToSurface(e.clientX, e.clientY);
       const node = createNode(p.x - NODE_DEFAULT_HALF_W, p.y - NODE_DEFAULT_HALF_H, '', {
         startEditing: true,
@@ -16766,6 +16777,7 @@
     }
 
     function addTextBoxAt(point, text, options) {
+      ensureKoseFont();
       const opts = options || {};
       const label = String(text == null ? '' : text);
       const wide = label.length > 3;
@@ -22950,6 +22962,7 @@
     function updateFormulaDragGhost(e) {
       if (!formulaDrag) return;
       if (!formulaDrag.ghost) {
+        ensureKoseFont();
         const ghost = document.createElement('div');
         ghost.className = 'formula-drag-ghost';
         ghost.textContent = formulaDrag.text;

--- a/assets/dual-viewer.html
+++ b/assets/dual-viewer.html
@@ -51,6 +51,7 @@
   <script src="markdown.js" defer></script>
   <script src="table-editor.js" defer></script>
   <script src="dual-clipboard.js" defer></script>
+  <script src="font-loader.js" defer></script>
   <script src="canvas.js" defer></script>
   <script src="dual-viewer.js" defer></script>
 </body>

--- a/assets/editor-lazy.js
+++ b/assets/editor-lazy.js
@@ -1,0 +1,135 @@
+// 编辑器非首屏运行时：先让画布和可见内容就绪，再在空闲期或首次交互时补齐功能。
+(function () {
+  'use strict';
+
+  const scriptJobs = new Map();
+  const styleJobs = new Map();
+
+  function loadScript(src) {
+    if (scriptJobs.has(src)) return scriptJobs.get(src);
+    const job = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = true;
+      script.addEventListener('load', resolve, { once: true });
+      script.addEventListener('error', () => reject(new Error('无法加载 ' + src)), { once: true });
+      document.head.appendChild(script);
+    });
+    scriptJobs.set(src, job);
+    return job;
+  }
+
+  function loadScriptsInOrder(sources) {
+    return sources.reduce((chain, src) => chain.then(() => loadScript(src)), Promise.resolve());
+  }
+
+  function loadStyle(href) {
+    if (styleJobs.has(href)) return styleJobs.get(href);
+    const job = new Promise((resolve, reject) => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = href;
+      link.addEventListener('load', resolve, { once: true });
+      link.addEventListener('error', () => reject(new Error('无法加载 ' + href)), { once: true });
+      document.head.appendChild(link);
+    });
+    styleJobs.set(href, job);
+    return job;
+  }
+
+  function scheduleIdle(task, timeout) {
+    if (typeof window.requestIdleCallback === 'function') {
+      window.requestIdleCallback(task, { timeout: timeout });
+    } else {
+      window.setTimeout(task, Math.min(timeout, 900));
+    }
+  }
+
+  let aiRuntimePromise = null;
+  function ensureAIRuntime() {
+    if (!aiRuntimePromise) {
+      aiRuntimePromise = loadScript('ai.js').then(() => {
+        window.RelatumAIReady = true;
+      });
+    }
+    return aiRuntimePromise;
+  }
+
+  const aiToggle = document.querySelector('[data-role="ai-toggle"]');
+  if (aiToggle) {
+    let aiOpening = false;
+    const openAIWhenReady = (event) => {
+      if (window.RelatumAIReady) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      if (aiOpening) return;
+      aiOpening = true;
+      aiToggle.setAttribute('aria-busy', 'true');
+      ensureAIRuntime().then(() => {
+        aiToggle.removeEventListener('click', openAIWhenReady, true);
+        aiToggle.removeAttribute('aria-busy');
+        window.RelatumAIReady = true;
+        aiToggle.click();
+      }).catch((error) => {
+        aiOpening = false;
+        aiToggle.removeAttribute('aria-busy');
+        console.warn('[编辑器] AI 运行时加载失败', error);
+      });
+    };
+    aiToggle.addEventListener('click', openAIWhenReady, true);
+  }
+
+  let graphRuntimePromise = null;
+  function ensureGraphRuntime() {
+    if (!graphRuntimePromise) {
+      graphRuntimePromise = loadScriptsInOrder(['graph-gl.js', 'graph-engine.js', 'graph-view.js'])
+        .then(() => document.dispatchEvent(new CustomEvent('editor:graph-runtime-ready')));
+    }
+    return graphRuntimePromise;
+  }
+
+  const graphToggle = document.querySelector('[data-action="graph"]');
+  if (graphToggle) {
+    graphToggle.disabled = false;
+    let graphOpening = false;
+    const openGraphWhenReady = (event) => {
+      if (window.GraphView) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      if (graphOpening) return;
+      graphOpening = true;
+      graphToggle.setAttribute('aria-busy', 'true');
+      ensureGraphRuntime().then(() => {
+        graphToggle.removeEventListener('click', openGraphWhenReady, true);
+        graphToggle.removeAttribute('aria-busy');
+        const open = () => graphToggle.click();
+        if (document.body.classList.contains('canvas-ready')) open();
+        else document.addEventListener('editor:canvasready', open, { once: true });
+      }).catch((error) => {
+        graphOpening = false;
+        graphToggle.removeAttribute('aria-busy');
+        console.warn('[编辑器] 图谱运行时加载失败', error);
+      });
+    };
+    graphToggle.addEventListener('click', openGraphWhenReady, true);
+  }
+
+  document.addEventListener('editor:ready', () => {
+    // 新手引导与说明框只影响首屏之后的辅助交互；样式和脚本一起延后，避免占用画布揭幕前的解析时间。
+    loadStyle('editor-onboarding.css').then(() => loadScript('editor-onboarding.js'))
+      .catch((error) => console.warn('[编辑器] 新手引导加载失败', error));
+    scheduleIdle(() => {
+      // 首次交互仍可抢先触发同一 Promise；若用户暂未操作，则在揭幕后空闲补齐，
+      // 避免第一次展开 AI 或图谱时才开始下载运行时。
+      ensureAIRuntime().catch((error) => console.warn('[编辑器] AI 运行时预热失败', error));
+      ensureGraphRuntime().catch((error) => console.warn('[编辑器] 图谱运行时预热失败', error));
+    }, 3200);
+    scheduleIdle(() => {
+      loadScript('tooltip.js').catch((error) => console.warn('[编辑器] 说明框加载失败', error));
+      // 空画布不再让 12MB 手写字体阻塞首屏；空闲后补齐，使首次使用文字工具时通常已就绪。
+      if (window.RelatumFontLoader && typeof window.RelatumFontLoader.ensureKose === 'function') {
+        window.RelatumFontLoader.ensureKose();
+      }
+    }, 2400);
+  }, { once: true });
+})();

--- a/assets/editor-onboarding.js
+++ b/assets/editor-onboarding.js
@@ -663,8 +663,9 @@
     window.setTimeout(function () { current.el.remove(); }, reduceMotion ? 0 : 220);
   }
 
-  document.addEventListener('editor:ready', function (event) {
-    readyState = event.detail || {};
+  function handleEditorReady(detail) {
+    if (readyState) return;
+    readyState = detail || {};
     if (!readyState.fresh || readyState.embed) return;
     let state = '';
     let initialLanguage = '';
@@ -680,7 +681,14 @@
       if (!initialLanguage && !savedLanguage) openLanguagePicker();
       else openGuide({ page: 0 });
     }, reduceMotion ? 180 : 620);
+  }
+
+  document.addEventListener('editor:ready', function (event) {
+    handleEditorReady(event.detail);
   });
+  if (window.__relatumEditorReadyDetail) {
+    handleEditorReady(window.__relatumEditorReadyDetail);
+  }
 
   document.addEventListener('relatum:languagechange', function () {
     renderReplayEntry();

--- a/assets/editor.html
+++ b/assets/editor.html
@@ -24,7 +24,6 @@
     html[data-editor-background-tone="dark"] { background: #101214; }
   </style>
   <link rel="stylesheet" href="styles.css">
-  <link rel="stylesheet" href="editor-onboarding.css">
   <!-- MathJax 3 — 本地化（X 轮）
        脚本由 canvas.js 在初始画布绘制完成后、浏览器空闲时加载。
        配置成不自动 typeset 整页——由 canvas.js 按节点显式调 typesetPromise，
@@ -43,6 +42,47 @@
       startup: { typeset: false }
     };
   </script>
+  <!-- URL 在 HTML 解析初期已经可用。先并行读取画布与背景，让本地 I/O 与 235KB 壳层解析、
+       核心脚本下载重叠；editor.js 会复用这些 Promise，不重复请求。 -->
+  <script>
+    (function () {
+      var file = '';
+      try { file = new URLSearchParams(location.search).get('file') || ''; } catch (e) {}
+      window.__relatumOpeningRequests = {
+        file: file,
+        canvas: file ? fetch('/api/load?path=' + encodeURIComponent(file))
+          .then(function (response) {
+            return response.json().then(function (json) { return { ok: response.ok, json: json }; });
+          })
+          .catch(function () { return { ok: false, json: { error: '读取失败' } }; }) : null,
+        background: fetch('/api/background-preference')
+          .then(function (response) { return response.ok ? response.json() : null; })
+          .catch(function () { return null; })
+      };
+    })();
+  </script>
+  <!-- 首屏核心使用 defer：浏览器在解析大型编辑器 DOM 时即可并行下载，仍严格按声明顺序执行。 -->
+  <script src="i18n.js" defer></script>
+  <script src="desktop-shell.js" defer></script>
+  <script src="sticky-palette.js" defer></script>
+  <script src="mermaid-renderer.js" defer></script>
+  <script src="richtext.js" defer></script>
+  <script src="markdown-table.js" defer></script>
+  <script src="markdown.js" defer></script>
+  <script src="table-editor.js" defer></script>
+  <script src="ruler.js" defer></script>
+  <script src="canvas-import.js" defer></script>
+  <script src="node-matrix.js" defer></script>
+  <script src="canvas-timer.js" defer></script>
+  <script src="markdown-notebook.js" defer></script>
+  <script src="canvas-scenes.js" defer></script>
+  <script src="canvas-taskbook.js" defer></script>
+  <script src="ai-canvas-plan.js" defer></script>
+  <script src="dual-clipboard.js" defer></script>
+  <script src="font-loader.js" defer></script>
+  <script src="canvas.js" defer></script>
+  <script src="editor-lazy.js" defer></script>
+  <script src="editor.js" defer></script>
 </head>
 <body class="editor-page">
   <!-- 首屏前同步设定模式 / 子模式，避免新建画布先闪一下完整顶栏再收起（editor.js 后续会再校准一次） -->
@@ -3634,30 +3674,5 @@
     </form>
   </aside>
 
-  <script src="i18n.js" defer></script>
-  <script src="desktop-shell.js" defer></script>
-  <script src="sticky-palette.js" defer></script>
-  <script src="mermaid-renderer.js" defer></script>
-  <script src="richtext.js" defer></script>
-  <script src="markdown-table.js" defer></script>
-  <script src="markdown.js" defer></script>
-  <script src="table-editor.js" defer></script>
-  <script src="ruler.js" defer></script>
-  <script src="canvas-import.js" defer></script>
-  <script src="node-matrix.js" defer></script>
-  <script src="canvas-timer.js" defer></script>
-  <script src="markdown-notebook.js" defer></script>
-  <script src="canvas-scenes.js" defer></script>
-  <script src="canvas-taskbook.js" defer></script>
-  <script src="ai-canvas-plan.js" defer></script>
-  <script src="dual-clipboard.js" defer></script>
-  <script src="canvas.js" defer></script>
-  <script src="graph-gl.js" defer></script>
-  <script src="graph-engine.js" defer></script>
-  <script src="graph-view.js" defer></script>
-  <script src="editor.js" defer></script>
-  <script src="editor-onboarding.js" defer></script>
-  <script src="ai.js" defer></script>
-  <script src="tooltip.js" defer></script>
 </body>
 </html>

--- a/assets/editor.js
+++ b/assets/editor.js
@@ -1028,9 +1028,14 @@
         if (openingCoverEl) {
           openingCoverEl.addEventListener('transitionend', () => openingCoverEl.remove(), { once: true });
         }
-        document.dispatchEvent(new CustomEvent('editor:ready', {
-          detail: { fresh: FRESH, embed: EMBED, nodes: canvasData && Array.isArray(canvasData.nodes) ? canvasData.nodes.length : 0 },
-        }));
+        const readyDetail = {
+          fresh: FRESH,
+          embed: EMBED,
+          nodes: canvasData && Array.isArray(canvasData.nodes) ? canvasData.nodes.length : 0,
+        };
+        // 延迟加载的新手引导可能在 editor:ready 派发后才执行；保留一份只读启动摘要供它补接。
+        window.__relatumEditorReadyDetail = readyDetail;
+        document.dispatchEvent(new CustomEvent('editor:ready', { detail: readyDetail }));
       });
     });
   }
@@ -9864,7 +9869,8 @@
         viewportEl.style.setProperty('--canvas-background-opacity', String(value));
       }
     };
-    setLayerOpacity(initial ? fadeTarget : 0);
+    // 图片不再阻塞画布揭幕：始终从透明开始，加载完成后在已就绪的画布背后淡入。
+    setLayerOpacity(0);
     return new Promise((resolve) => {
       const probe = new Image();
       probe.addEventListener('load', () => {
@@ -9873,11 +9879,6 @@
           return;
         }
         applyLoadedImage(source, bg);
-        if (initial) {
-          setLayerOpacity(fadeTarget);
-          resolve();
-          return;
-        }
         requestAnimationFrame(() => {
           if (version === backgroundProbeVersion) setLayerOpacity(fadeTarget);
           resolve();
@@ -10224,12 +10225,21 @@
   }
 
   // ── 加载（并行请求画布数据 + 全局背景偏好）───────
-  Promise.all([
-    fetch('/api/load?path=' + encodeURIComponent(filePath))
-      .then((r) => r.json().then((j) => ({ ok: r.ok, json: j }))),
-    fetch('/api/background-preference')
+  const openingRequests = window.__relatumOpeningRequests;
+  const canvasOpeningRequest = openingRequests
+    && openingRequests.file === filePath
+    && openingRequests.canvas
+    ? openingRequests.canvas
+    : fetch('/api/load?path=' + encodeURIComponent(filePath))
+      .then((r) => r.json().then((j) => ({ ok: r.ok, json: j })));
+  const backgroundOpeningRequest = openingRequests && openingRequests.background
+    ? openingRequests.background
+    : fetch('/api/background-preference')
       .then((r) => r.ok ? r.json() : null)
-      .catch(() => null),
+      .catch(() => null);
+  Promise.all([
+    canvasOpeningRequest,
+    backgroundOpeningRequest,
   ])
     .then(async ([{ ok, json }, bgJson]) => {
       if (!ok) {
@@ -10248,6 +10258,10 @@
       canvasData = json.data || { version: 2, nodes: [], edges: [] };
       if (!Array.isArray(canvasData.nodes)) canvasData.nodes = [];
       if (!Array.isArray(canvasData.edges)) canvasData.edges = [];
+      const typographyReady = window.RelatumFontLoader
+        && typeof window.RelatumFontLoader.prepareCanvas === 'function'
+        ? window.RelatumFontLoader.prepareCanvas(canvasData)
+        : Promise.resolve();
       if (titleEl) titleEl.textContent = json.title || '画布';
       // 数据已加载成功：立即启用标题改名。早于画布渲染绑定，确保即便后续渲染 / 桥接出意外，
       // 标题改名也始终可用（此前它排在渲染之后，渲染一抛错就被整段跳过 → 改不了名）。
@@ -10268,6 +10282,10 @@
       setupBackgroundPanel();
       const backgroundReady = renderBackground({ initial: true });
       renderGuide();
+
+      // 只有确实包含手写文字/文字框的旧画布才等待对应字体，避免字体后到导致内容跳位。
+      // 普通画布直接越过这一步，12MB 手写字体留到首屏完成后的空闲期补齐。
+      await typographyReady;
 
       // 启动画布交互（canvas.js 直接 mutate canvasData.nodes）
       if (window.CanvasModule) {
@@ -10351,8 +10369,8 @@
             cleanBtn.hidden = true;
           }
         }
-      // 背景、画布和标题都已是最终状态，再统一揭开开场遮罩。
-      await backgroundReady;
+      // 标题、画布和背景底色已是最终状态即可揭幕；位图背景继续在背后加载并淡入。
+      backgroundReady.catch((error) => console.warn('[画布] 背景恢复失败', error));
       finishEditorOpening();
     })
     .catch((err) => {
@@ -10743,6 +10761,7 @@
       graphView.open(canvasData, titleEl ? titleEl.textContent : '画布');
     });
   }
+  document.addEventListener('editor:graph-runtime-ready', setupGraphPanel);
 
   // 脑图：顶栏按钮弹出布局菜单 → 调 CanvasModule.applyMindmap(layout)
   if (mindmapBtn && mindmapMenu) {

--- a/assets/font-loader.js
+++ b/assets/font-loader.js
@@ -1,0 +1,40 @@
+// 大体积展示字体按需注册，避免仅解析全局 CSS 就下载 12MB KoseFont。
+(function () {
+  'use strict';
+
+  let koseFontPromise = null;
+
+  function ensureKoseFont() {
+    if (koseFontPromise) return koseFontPromise;
+    koseFontPromise = new Promise((resolve) => {
+      if (!document.getElementById('relatum-kose-font-face')) {
+        const style = document.createElement('style');
+        style.id = 'relatum-kose-font-face';
+        style.textContent = '@font-face{font-family:"KoseFont";src:url("fonts/kose-font.woff2") format("woff2");font-weight:normal;font-style:normal;font-display:swap;}';
+        document.head.appendChild(style);
+      }
+      if (!document.fonts || typeof document.fonts.load !== 'function') {
+        resolve();
+        return;
+      }
+      document.fonts.load('16px "KoseFont"').then(resolve, resolve);
+    });
+    return koseFontPromise;
+  }
+
+  function canvasNeedsKoseFont(data) {
+    const nodes = data && Array.isArray(data.nodes) ? data.nodes : [];
+    return nodes.some((node) => node && (
+      node.handText === true
+      || node.kind === 'textBox'
+      || (node.kind === 'box' && Array.isArray(node.groupMemberIds) && node.groupMemberIds.length > 0)
+    ));
+  }
+
+  window.RelatumFontLoader = {
+    ensureKose: ensureKoseFont,
+    prepareCanvas: function (data) {
+      return canvasNeedsKoseFont(data) ? ensureKoseFont() : Promise.resolve();
+    },
+  };
+})();

--- a/assets/start.js
+++ b/assets/start.js
@@ -146,16 +146,12 @@
       source = '/sky-dark.png';
     }
     if (!source) return;
-    const preload = () => {
-      const image = new Image();
-      image.decoding = 'async';
-      image.src = source;
-    };
-    if ('requestIdleCallback' in window) {
-      window.requestIdleCallback(preload, { timeout: 1000 });
-    } else {
-      window.setTimeout(preload, 0);
-    }
+    // 背景偏好返回后立即以低优先级预热。此前放进 requestIdleCallback，用户在
+    // 一秒内打开画布时导航往往先发生，预热还没开始；现在配合 ETag 缓存可跨页复用。
+    const image = new Image();
+    image.decoding = 'async';
+    try { image.fetchPriority = 'low'; } catch (e) {}
+    image.src = source;
   }
 
   // 编辑器首帧需要在 /api/load 返回前选好深浅等待底色。起步页提前同步语义，

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -6,14 +6,6 @@
    - hairline 边框 + 极轻阴影
 */
 
-@font-face {
-  font-family: 'KoseFont';
-  src: url('fonts/kose-font.woff2') format('woff2');
-  font-weight: normal;
-  font-style: normal;
-  font-display: swap;
-}
-
 /* 目标树 V4.1：阶段解锁路线。常用进度操作直接位于任务节点，低频编辑使用临时弹层。 */
 .study-route-overlay {
   position: fixed;

--- a/tests/editor-opening-performance-contract.js
+++ b/tests/editor-opening-performance-contract.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const read = (name) => fs.readFileSync(path.join(root, name), 'utf8');
+const html = read('assets/editor.html');
+const lazy = read('assets/editor-lazy.js');
+const fontLoader = read('assets/font-loader.js');
+const dualViewer = read('assets/dual-viewer.html');
+const editor = read('assets/editor.js');
+const start = read('assets/start.js');
+const styles = read('assets/styles.css');
+const app = read('app.py');
+
+assert(html.includes('<script src="editor-lazy.js" defer></script>'));
+assert(html.indexOf('<script src="canvas.js" defer></script>') < html.indexOf('</head>'), 'critical scripts must be discovered from head');
+assert(html.includes('window.__relatumOpeningRequests'));
+['graph-gl.js', 'graph-engine.js', 'graph-view.js', 'editor-onboarding.js', 'ai.js', 'tooltip.js']
+  .forEach((source) => assert(!html.includes('<script src="' + source + '" defer></script>'), source + ' must stay off the critical path'));
+assert(!html.includes('<link rel="stylesheet" href="editor-onboarding.css">'));
+
+assert(lazy.includes("loadScriptsInOrder(['graph-gl.js', 'graph-engine.js', 'graph-view.js'])"));
+assert(lazy.includes("loadScript('ai.js')"));
+assert(lazy.includes('ensureAIRuntime().catch'));
+assert(lazy.includes('ensureGraphRuntime().catch'));
+assert(lazy.includes('}, 3200);'), 'AI and graph runtimes should warm only after the editor enters an idle period');
+assert(lazy.includes("loadStyle('editor-onboarding.css')"));
+assert(lazy.includes("loadScript('tooltip.js')"));
+assert(fontLoader.includes('window.RelatumFontLoader'));
+assert(fontLoader.includes("document.fonts.load('16px \"KoseFont\"')"));
+assert(html.includes('<script src="font-loader.js" defer></script>'));
+assert(dualViewer.includes('<script src="font-loader.js" defer></script>'));
+assert(!styles.includes("src: url('fonts/kose-font.woff2')"), 'the 12MB handwriting font must not be discovered from critical CSS');
+
+assert(editor.includes('window.__relatumEditorReadyDetail = readyDetail'));
+assert(editor.includes('const canvasOpeningRequest = openingRequests'));
+assert(editor.includes("document.addEventListener('editor:graph-runtime-ready', setupGraphPanel)"));
+assert(editor.includes("backgroundReady.catch((error) => console.warn('[画布] 背景恢复失败', error))"));
+assert(!editor.includes('await backgroundReady;'), 'background images must not hold the opening cover');
+assert(editor.includes('setLayerOpacity(0);'));
+
+assert(start.includes("image.fetchPriority = 'low'"));
+assert(!/requestIdleCallback\(preload/.test(start), 'background warming must begin before a fast navigation can cancel it');
+assert(app.includes('cache_control="private, no-cache"'));
+assert(app.includes('If-None-Match'));
+assert(app.includes('self.send_response(304)'));
+
+console.log('editor opening performance contract: ok');


### PR DESCRIPTION
## 改动

- 在 HTML 解析早期并行读取画布数据与全局背景偏好，编辑器复用同一请求
- 将 AI、图谱、新手引导和说明框移出首屏阻塞链
- AI 与图谱支持首次交互抢先加载，并在编辑器揭幕后空闲预热
- KoseFont 改为按画布内容与空闲阶段加载
- 背景图片使用 ETag 私有缓存复检，不再阻塞画布揭幕
- 增加编辑器打开性能契约测试并更新维护文档

## 原因与影响

普通画布打开时间主要受固定编辑器壳、脚本、字体和背景图片影响，而不是 `.canvas` 数据本身。本次调整减少首屏阻塞资源，同时保留首次功能交互的即时响应；图片背景会在画布揭幕后淡入。

## 验证

- `node tests/editor-opening-performance-contract.js`
- `node tests/canvas-performance-contract.js`
- `node tests/editor-settings-reset-contract.js`
- `python -m unittest discover -s tests`（144 项通过）
- JavaScript 语法检查与 `python -m py_compile app.py`
- 隔离本地页面验证：AI/图谱空闲预热、首次展开、背景 200→304 ETag 复检、控制台无错误
