### PR TITLE
Fix cadence detail entrance replay

### DIFF
--- a/assets/start.js
+++ b/assets/start.js
@@ -1792,7 +1792,14 @@
     }
     if (resetClass) {
       const cadence = document.querySelector('[data-role="study-cadence"]');
-      if (cadence) cadence.classList.remove('cadence-entering', 'cadence-staging');
+      if (cadence) {
+        cadence.classList.remove('cadence-entering', 'cadence-staging');
+        // 镜头或日期切换会留下局部刷新动画类，它在当前页内用来避免
+        // 整页与局部动画重叠；离页或重新武装入场时必须清掉，否则详情栏会被
+        // .cadence-entering ... :not(.is-refreshing) 永久排除。
+        const detail = cadence.querySelector('[data-role="cadence-day-detail"]');
+        if (detail) detail.classList.remove('is-refreshing');
+      }
     }
   }
   function stageCadenceEntrance() {


### PR DESCRIPTION
## What changed

- Clear the activity detail panel's one-shot `is-refreshing` state when leaving or re-arming the activity page entrance.
- Preserve the existing in-page lens/date refresh animation behavior.

## Why

After switching among the Canvas, Complete, and Focus lenses, the detail panel kept `is-refreshing`. The page entrance selector intentionally excludes that state, so the “使用 xx 张画布” detail section stopped participating in later staggered entrances until the app rebuilt the DOM on restart.

## Impact

Re-entering the activity page now replays the detail section in the same staggered sequence as the rest of the page, regardless of prior lens switches.

## Checks

- `git diff --check`
- `node --check assets/start.js`
- UI acceptance intentionally left to the requester
